### PR TITLE
Fix dark mode inconsistencies across pages (issue #17)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,14 +61,15 @@ code {
 }
 
 /* Dark mode table styling */
-[data-bs-theme="dark"] .table thead,
 [data-bs-theme="dark"] .table thead.bg-light,
 [data-bs-theme="dark"] thead.bg-light {
-  background-color: var(--bs-light);
+  background-color: var(--bs-dark);
+  color: var(--bs-body-color);
 }
 
 [data-bs-theme="dark"] .table th {
   border-color: #495057;
+  color: var(--bs-body-color);
 }
 
 [data-bs-theme="dark"] .table td {
@@ -181,7 +182,7 @@ code {
 
 /* Fix for card headers with bg-light class in dark mode */
 [data-bs-theme="dark"] .card-header.bg-light {
-  background-color: var(--bs-light) !important;
+  background-color: var(--bs-dark) !important;
   color: var(--bs-body-color);
 }
 


### PR DESCRIPTION
This PR fixes the dark mode inconsistencies across the application as described in issue #17.

## Changes:
- Fixed table headers with bg-light class in dark mode by setting their background color to var(--bs-dark) instead of var(--bs-light)
- Fixed card headers with bg-light class in dark mode by setting their background color to var(--bs-dark) instead of var(--bs-light)

These changes ensure that all pages render dark mode correctly and consistently throughout the application, matching the styling of the User Management page.

Closes #17