### PR TITLE
Fix calibration timeframe selector visibility issue

### DIFF
--- a/frontend/src/components/calibration/CalibrationDueList.jsx
+++ b/frontend/src/components/calibration/CalibrationDueList.jsx
@@ -45,45 +45,48 @@ const CalibrationDueList = () => {
     );
   }
 
-  if (tools.length === 0) {
-    return (
-      <Alert variant="info">
-        <Alert.Heading>No Calibrations Due</Alert.Heading>
-        <p>There are no tools due for calibration in the next {days} days.</p>
-      </Alert>
-    );
-  }
+  // Always render the timeframe selector
+  const renderTimeframeSelector = () => (
+    <div className="mb-3">
+      <div className="d-flex align-items-center mb-3">
+        <span className="me-2">Show tools due for calibration in the next:</span>
+        <div className="btn-group">
+          <Button
+            variant={days === 7 ? 'primary' : 'outline-primary'}
+            onClick={() => setDays(7)}
+            size="sm"
+          >
+            7 Days
+          </Button>
+          <Button
+            variant={days === 30 ? 'primary' : 'outline-primary'}
+            onClick={() => setDays(30)}
+            size="sm"
+          >
+            30 Days
+          </Button>
+          <Button
+            variant={days === 90 ? 'primary' : 'outline-primary'}
+            onClick={() => setDays(90)}
+            size="sm"
+          >
+            90 Days
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div>
-      <div className="mb-3">
-        <div className="d-flex align-items-center mb-3">
-          <span className="me-2">Showing tools due for calibration in the next:</span>
-          <div className="btn-group">
-            <Button
-              variant={days === 7 ? 'primary' : 'outline-primary'}
-              onClick={() => setDays(7)}
-              size="sm"
-            >
-              7 Days
-            </Button>
-            <Button
-              variant={days === 30 ? 'primary' : 'outline-primary'}
-              onClick={() => setDays(30)}
-              size="sm"
-            >
-              30 Days
-            </Button>
-            <Button
-              variant={days === 90 ? 'primary' : 'outline-primary'}
-              onClick={() => setDays(90)}
-              size="sm"
-            >
-              90 Days
-            </Button>
-          </div>
-        </div>
-      </div>
+      {renderTimeframeSelector()}
+
+      {tools.length === 0 ? (
+        <Alert variant="info">
+          <Alert.Heading>No Calibrations Due</Alert.Heading>
+          <p>There are no tools due for calibration in the next {days} days.</p>
+        </Alert>
+      ) : (
 
       <Table striped bordered hover responsive>
         <thead>
@@ -102,7 +105,7 @@ const CalibrationDueList = () => {
             const nextDate = new Date(tool.next_calibration_date);
             const today = new Date();
             const daysRemaining = Math.ceil((nextDate - today) / (1000 * 60 * 60 * 24));
-            
+
             return (
               <tr key={tool.id}>
                 <td>{tool.tool_number}</td>
@@ -144,6 +147,7 @@ const CalibrationDueList = () => {
           })}
         </tbody>
       </Table>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Fixes #24

The timeframe selector in the Calibration Due Soon tab now remains visible even when there are no calibrations due. This allows users to switch between different timeframes (7 days, 30 days, 90 days) without having to refresh the page.

### Changes made:
- Modified the CalibrationDueList component to always render the timeframe selector
- Restructured the component to use conditional rendering for the table or alert message while keeping the selector visible
- Improved the selector text for better clarity

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The timeframe selector is now always visible at the top of the calibration due list, even when no calibrations are due.
  - Improved clarity and consistency in the display of the "No Calibrations Due" alert and tool list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->