### PR TITLE
Fix Chemical Reorder Delivery Issue (#106)

### DIFF
--- a/frontend/src/store/chemicalsSlice.js
+++ b/frontend/src/store/chemicalsSlice.js
@@ -259,9 +259,9 @@ export const markChemicalAsOrdered = createAsyncThunk(
 
 export const markChemicalAsDelivered = createAsyncThunk(
   'chemicals/markChemicalAsDelivered',
-  async (id, { rejectWithValue }) => {
+  async ({ id, receivedQuantity }, { rejectWithValue }) => {
     try {
-      const data = await ChemicalService.markChemicalAsDelivered(id);
+      const data = await ChemicalService.markChemicalAsDelivered(id, receivedQuantity);
       return data;
     } catch (error) {
       return rejectWithValue(error.response?.data || { message: 'Failed to mark chemical as delivered' });
@@ -637,6 +637,9 @@ const chemicalsSlice = createSlice({
         const chemicalIndex = state.chemicals.findIndex(c => c.id === updatedChemical.id);
         if (chemicalIndex !== -1) {
           state.chemicals[chemicalIndex] = updatedChemical;
+        } else {
+          // If the chemical doesn't exist in the main list, add it
+          state.chemicals.push(updatedChemical);
         }
 
         // Remove from chemicals on order


### PR DESCRIPTION
## Description
This PR fixes issue #106 where chemicals marked as delivered were not properly added to the active chemicals list with the correct quantity.

## Changes Made
- Updated the frontend to prompt for the received quantity when marking a chemical as delivered
- Modified the `markChemicalAsDelivered` function in the chemicalsSlice.js to pass the received quantity to the backend
- Updated the ChemicalsOnOrder component to refresh both the chemicals on order list and the active chemicals list when a chemical is marked as delivered

## Testing
- Tested the fix by marking a chemical as ordered and then marking it as delivered with a specific quantity
- Verified that the chemical was properly removed from the "On Order" tab
- Verified that the chemical was properly added to the "Active Chemicals" list with the correct quantity
- Verified that the chemical was properly removed from the "Needs Reorder" tab

## Screenshots
N/A

## Related Issues
Closes #106

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introducing a modal dialog when marking a chemical as delivered, allowing users to enter the received quantity before confirming delivery.

- **Improvements**
  - Enhanced inventory status updates to better reflect chemical availability and archival state after delivery.
  - Chemicals marked as delivered are now correctly added to the main chemicals list if missing.

- **Bug Fixes**
  - Prevented duplicate submissions when marking chemicals as delivered.
  - Improved validation to ensure only positive quantities can be submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->