### PR TITLE
Fix calibration due alert discrepancy between Tools and Calibration Reports pages

### DIFF
--- a/backend/routes_calibration.py
+++ b/backend/routes_calibration.py
@@ -80,12 +80,18 @@ def register_calibration_routes(app):
             threshold_date = now + timedelta(days=days)
 
             # Find tools that require calibration and are due within the specified days
+            # Use the calibration_status field to ensure consistency across the application
             tools = Tool.query.filter(
                 Tool.requires_calibration == True,
                 Tool.next_calibration_date.isnot(None),
-                Tool.next_calibration_date <= threshold_date,
-                Tool.next_calibration_date >= now
+                Tool.calibration_status == 'due_soon' if days == 30 else
+                    ((Tool.next_calibration_date <= threshold_date) & (Tool.next_calibration_date >= now))
             ).all()
+
+            # Log the query results for debugging
+            print(f"Found {len(tools)} tools due for calibration in the next {days} days")
+            for tool in tools:
+                print(f"Tool ID: {tool.id}, Tool Number: {tool.tool_number}, Next Calibration Date: {tool.next_calibration_date}, Status: {tool.calibration_status}")
 
             return jsonify([tool.to_dict() for tool in tools]), 200
 


### PR DESCRIPTION
## Description

This PR fixes the discrepancy in calibration due alerts between the Tools page and the Calibration Reports page (Issue #125).

## Changes Made

Modified the `get_calibrations_due` function in `routes_calibration.py` to use the `calibration_status` field when the `days` parameter is set to 30, ensuring consistency between the Tools page alert and the Calibration Reports page.

## Testing

1. Verified that the Tools page shows an alert for tools due for calibration in the next 30 days
2. Verified that the Calibration Reports page now correctly shows the same tools when generating a report for calibrations due within the next 30 days

## Related Issues

Closes #125

## Screenshots

N/A

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of calibration due listings by adjusting filtering logic for 30-day queries.
- **Chores**
  - Enhanced logging to provide more detailed information about calibration queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->