### PR TITLE
Fix redundant UI elements on several pages (issue #124)

### DIFF
--- a/frontend/src/components/reports/tables/ToolInventoryTable.jsx
+++ b/frontend/src/components/reports/tables/ToolInventoryTable.jsx
@@ -35,7 +35,7 @@ const ToolInventoryTable = ({ data }) => {
   const sortedTools = [...filteredTools].sort((a, b) => {
     const aValue = a[sortField] || '';
     const bValue = b[sortField] || '';
-    
+
     if (sortDirection === 'asc') {
       return aValue.localeCompare(bValue);
     } else {
@@ -133,7 +133,7 @@ const ToolInventoryTable = ({ data }) => {
       <Card className="shadow-sm">
         <Card.Header className="bg-light">
           <div className="d-flex justify-content-between align-items-center">
-            <h5 className="mb-0">Tool Inventory</h5>
+            <h5 className="mb-0">Details</h5>
             <InputGroup style={{ width: '300px' }}>
               <InputGroup.Text>
                 <i className="bi bi-search"></i>
@@ -152,7 +152,7 @@ const ToolInventoryTable = ({ data }) => {
             <Table hover className="mb-0">
               <thead className="bg-light">
                 <tr>
-                  <th 
+                  <th
                     onClick={() => handleSort('tool_number')}
                     className="cursor-pointer"
                   >
@@ -160,7 +160,7 @@ const ToolInventoryTable = ({ data }) => {
                       <i className={`bi bi-arrow-${sortDirection === 'asc' ? 'up' : 'down'}`}></i>
                     )}
                   </th>
-                  <th 
+                  <th
                     onClick={() => handleSort('serial_number')}
                     className="cursor-pointer"
                   >
@@ -168,7 +168,7 @@ const ToolInventoryTable = ({ data }) => {
                       <i className={`bi bi-arrow-${sortDirection === 'asc' ? 'up' : 'down'}`}></i>
                     )}
                   </th>
-                  <th 
+                  <th
                     onClick={() => handleSort('description')}
                     className="cursor-pointer"
                   >
@@ -176,7 +176,7 @@ const ToolInventoryTable = ({ data }) => {
                       <i className={`bi bi-arrow-${sortDirection === 'asc' ? 'up' : 'down'}`}></i>
                     )}
                   </th>
-                  <th 
+                  <th
                     onClick={() => handleSort('category')}
                     className="cursor-pointer"
                   >
@@ -184,7 +184,7 @@ const ToolInventoryTable = ({ data }) => {
                       <i className={`bi bi-arrow-${sortDirection === 'asc' ? 'up' : 'down'}`}></i>
                     )}
                   </th>
-                  <th 
+                  <th
                     onClick={() => handleSort('location')}
                     className="cursor-pointer"
                   >
@@ -192,7 +192,7 @@ const ToolInventoryTable = ({ data }) => {
                       <i className={`bi bi-arrow-${sortDirection === 'asc' ? 'up' : 'down'}`}></i>
                     )}
                   </th>
-                  <th 
+                  <th
                     onClick={() => handleSort('status')}
                     className="cursor-pointer"
                   >

--- a/frontend/src/components/tools/ToolList.jsx
+++ b/frontend/src/components/tools/ToolList.jsx
@@ -164,7 +164,6 @@ const ToolList = () => {
         <Card.Header className="bg-light">
           <div className="d-flex flex-wrap justify-content-between align-items-center gap-3">
             <div className="d-flex align-items-center">
-              <h5 className="mb-0">Tool Inventory</h5>
               {showHelp && (
                 <HelpIcon
                   title="Tool Inventory"

--- a/frontend/src/pages/CalibrationManagement.jsx
+++ b/frontend/src/pages/CalibrationManagement.jsx
@@ -46,7 +46,7 @@ const CalibrationManagement = () => {
           <Col md={3} lg={2} className="mb-4">
             <Card>
               <Card.Header>
-                <h5 className="mb-0">Calibration</h5>
+                <h5 className="mb-0">Navigation</h5>
               </Card.Header>
               <Card.Body className="p-0">
                 <Nav variant="pills" className="flex-column">


### PR DESCRIPTION
## Description

This PR addresses issue #124 by removing redundant UI elements from several pages of the application.

## Changes Made

1. **Tools Page**:
   - Removed the redundant "Tool Inventory" heading from the `ToolList.jsx` component
   - The main heading in `ToolsManagement.jsx` is now the only "Tool Inventory" heading on the page

2. **Reports Page**:
   - Changed the redundant "Tool Inventory" heading to "Details" in the `ToolInventoryTable.jsx` component
   - This makes the UI cleaner and avoids duplication

3. **Calibrations Page**:
   - Changed the redundant "Calibration" heading to "Navigation" in the `CalibrationManagement.jsx` component
   - This better describes the purpose of that section

## Testing

The application was tested by running both the frontend and backend servers and verifying that the UI elements were properly displayed without redundancy.

## Screenshots

N/A

## Closes

Closes #124

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated various UI headings for improved clarity: changed "Tool Inventory" to "Details" in the tool inventory table, removed the "Tool Inventory" heading from the tool list, and updated the sidebar label from "Calibration" to "Navigation."
  - Minor formatting adjustments to table headers for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->