### PR TITLE
Fix tool assignment inconsistency between dashboard and All Checkouts page

### DIFF
--- a/frontend/src/components/dashboard/PastDueTools.jsx
+++ b/frontend/src/components/dashboard/PastDueTools.jsx
@@ -1,0 +1,144 @@
+import { useState, useEffect, useRef } from 'react';
+import { Card, ListGroup, Badge, Button, Alert } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import api from '../../services/api';
+
+const PastDueTools = () => {
+  const [pastDueTools, setPastDueTools] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const { user } = useSelector((state) => state.auth);
+  const isAdmin = user?.is_admin || user?.department === 'Materials';
+  const dataFetchedRef = useRef(false);
+
+  useEffect(() => {
+    // Only fetch overdue tools if user is admin or in Materials department
+    // and if we haven't already fetched the data
+    if (isAdmin && !dataFetchedRef.current) {
+      fetchOverdueTools();
+      dataFetchedRef.current = true;
+    }
+  }, [isAdmin]);
+
+  const fetchOverdueTools = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await api.get('/checkouts/overdue');
+      setPastDueTools(response.data);
+    } catch (err) {
+      console.error('Error fetching overdue tools:', err);
+      setError('Failed to load overdue tools data');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Only show to admins and Materials department
+  if (!isAdmin) {
+    return null;
+  }
+
+  // Function to determine badge color based on days overdue
+  const getOverdueBadgeVariant = (daysOverdue) => {
+    if (daysOverdue > 14) return 'danger';
+    if (daysOverdue > 7) return 'warning';
+    return 'info';
+  };
+
+  // Function to format date
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString();
+  };
+
+  if (loading) {
+    return (
+      <Card className="shadow-sm mb-4">
+        <Card.Header className="bg-light">
+          <h4 className="mb-0">Past Due Tools</h4>
+        </Card.Header>
+        <Card.Body className="text-center p-4">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="shadow-sm mb-4">
+        <Card.Header className="bg-light">
+          <h4 className="mb-0">Past Due Tools</h4>
+        </Card.Header>
+        <Card.Body>
+          <Alert variant="warning">
+            {error}
+          </Alert>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (pastDueTools.length === 0) {
+    return (
+      <Card className="shadow-sm mb-4">
+        <Card.Header className="bg-light">
+          <h4 className="mb-0">Past Due Tools</h4>
+        </Card.Header>
+        <Card.Body>
+          <Alert variant="success">
+            No overdue tools at this time.
+          </Alert>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-sm mb-4">
+      <Card.Header className="bg-light d-flex justify-content-between align-items-center">     
+        <h4 className="mb-0">Past Due Tools</h4>
+        <Badge bg="danger" pill>{pastDueTools.length}</Badge>
+      </Card.Header>
+      <Card.Body className="p-0">
+        <ListGroup variant="flush">
+          {pastDueTools.map((tool) => (
+            <ListGroup.Item key={tool.id} className="d-flex justify-content-between align-items-center">
+              <div>
+                <div className="fw-bold">{tool.tool_number} - {tool.description}</div>
+                <div className="text-muted small">
+                  Checked out by: {tool.user_name} | Due: {formatDate(tool.expected_return_date)}
+                </div>
+              </div>
+              <div className="d-flex align-items-center">
+                <Badge
+                  bg={getOverdueBadgeVariant(tool.days_overdue)}
+                  className="me-2"
+                >
+                  {tool.days_overdue} days overdue
+                </Badge>
+                <Button
+                  as={Link}
+                  to={`/checkouts/all`}
+                  variant="outline-primary"
+                  size="sm"
+                >
+                  View
+                </Button>
+              </div>
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      </Card.Body>
+      <Card.Footer>
+        <Button as={Link} to="/checkouts/all" variant="danger" className="w-100">Manage Overdue Tools</Button>
+      </Card.Footer>
+    </Card>
+  );
+};
+
+export default PastDueTools;

--- a/frontend/src/components/dashboard/UserCheckoutStatus.jsx
+++ b/frontend/src/components/dashboard/UserCheckoutStatus.jsx
@@ -7,34 +7,34 @@ import { formatDate } from '../../utils/dateUtils';
 
 const UserCheckoutStatus = () => {
   const dispatch = useDispatch();
-  const { checkouts, loading, error } = useSelector((state) => state.checkouts);
+  const { userCheckouts, loading, error } = useSelector((state) => state.checkouts);
   const { user } = useSelector((state) => state.auth);
-  
+
   useEffect(() => {
     dispatch(fetchUserCheckouts());
   }, [dispatch]);
 
   // Filter active checkouts (not returned)
-  const activeCheckouts = checkouts.filter(checkout => !checkout.return_date);
+  const activeCheckouts = userCheckouts.filter(checkout => !checkout.return_date);
 
   // Function to determine badge variant based on due date
   const getStatusBadgeVariant = (dueDate) => {
     if (!dueDate) return 'secondary';
-    
+
     const today = new Date();
     const due = new Date(dueDate);
-    
+
     if (due < today) return 'danger'; // Overdue
-    
+
     // Calculate days until due
     const diffTime = Math.abs(due - today);
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    
+
     if (diffDays <= 2) return 'warning'; // Due soon
     return 'success'; // Not due soon
   };
 
-  if (loading && !checkouts.length) {
+  if (loading && !userCheckouts.length) {
     return (
       <Card className="shadow-sm mb-4">
         <Card.Header className="bg-light">
@@ -83,13 +83,13 @@ const UserCheckoutStatus = () => {
             {activeCheckouts.map((checkout) => {
               const dueDate = checkout.expected_return_date;
               const badgeVariant = getStatusBadgeVariant(dueDate);
-              
+
               return (
                 <ListGroup.Item key={checkout.id} className="d-flex justify-content-between align-items-center">
                   <div>
                     <div className="fw-bold">{checkout.tool_number} - {checkout.description}</div>
                     <div className="text-muted small">
-                      Checked out: {formatDate(checkout.checkout_date)} | 
+                      Checked out: {formatDate(checkout.checkout_date)} |
                       Due: {formatDate(checkout.expected_return_date)}
                     </div>
                   </div>
@@ -98,7 +98,7 @@ const UserCheckoutStatus = () => {
                       bg={badgeVariant}
                       className="me-2"
                     >
-                      {badgeVariant === 'danger' ? 'Overdue' : 
+                      {badgeVariant === 'danger' ? 'Overdue' :
                        badgeVariant === 'warning' ? 'Due Soon' : 'Checked Out'}
                     </Badge>
                     <Button

--- a/frontend/src/pages/UserDashboardPage.jsx
+++ b/frontend/src/pages/UserDashboardPage.jsx
@@ -7,6 +7,7 @@ import UserCheckoutStatus from '../components/dashboard/UserCheckoutStatus';
 import RecentActivity from '../components/dashboard/RecentActivity';
 import Announcements from '../components/dashboard/Announcements';
 import QuickActions from '../components/dashboard/QuickActions';
+import PastDueTools from '../components/dashboard/PastDueTools';
 
 const UserDashboardPage = () => {
   const { user } = useSelector((state) => state.auth);
@@ -24,22 +25,25 @@ const UserDashboardPage = () => {
           <Col lg={8}>
             {/* Notifications Section */}
             <CalibrationNotifications />
-            
+
             {/* Only show OverdueChemicals to admins and Materials department */}
             {isAdmin && <OverdueChemicals />}
-            
+
+            {/* Only show PastDueTools to admins and Materials department */}
+            {isAdmin && <PastDueTools />}
+
             {/* User's Checked Out Tools */}
             <UserCheckoutStatus />
-            
+
             {/* Recent Activity */}
             <RecentActivity />
           </Col>
-          
+
           {/* Sidebar - 1/3 width on large screens */}
           <Col lg={4}>
             {/* Announcements */}
             <Announcements />
-            
+
             {/* Quick Actions */}
             <QuickActions />
           </Col>


### PR DESCRIPTION
## Description

This PR fixes the issue described in #144 where there was a discrepancy in the user assignment for tools between the dashboard and the All Checkouts page.

## Changes Made

- Fixed the `UserCheckoutStatus` component to use the correct data source (`userCheckouts` instead of `checkouts`)
- Added the `PastDueTools` component to the dashboard to display overdue tools with correct user assignments
- Updated the `UserDashboardPage` to include the `PastDueTools` component

## Testing

- Verified that the dashboard now shows the correct user assignments for tools
- Verified that the All Checkouts page shows the same user assignments as the dashboard

## Related Issues

Fixes #144

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dashboard section displaying overdue tools for admins and Materials department users, including detailed information and severity badges.
- **Improvements**
  - System resource monitoring now works even if system metrics cannot be gathered, displaying mock data when necessary.
- **Bug Fixes**
  - Updated dashboard to ensure overdue tools and user checkout status display correctly based on user roles and improved state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->