### PR TITLE
Fix dashboard checkout discrepancy (Issue #142)

### DIFF
--- a/frontend/src/components/dashboard/PastDueTools.jsx
+++ b/frontend/src/components/dashboard/PastDueTools.jsx
@@ -100,11 +100,15 @@ const PastDueTools = () => {
 
   return (
     <Card className="shadow-sm mb-4">
-      <Card.Header className="bg-light d-flex justify-content-between align-items-center">     
+      <Card.Header className="bg-light d-flex justify-content-between align-items-center">
         <h4 className="mb-0">Past Due Tools</h4>
         <Badge bg="danger" pill>{pastDueTools.length}</Badge>
       </Card.Header>
       <Card.Body className="p-0">
+        <Alert variant="info" className="m-2 mb-0">
+          This section shows tools checked out to <strong>all users</strong> that are past their due date.
+          To see only your checkouts, check the "My Checked Out Tools" section below.
+        </Alert>
         <ListGroup variant="flush">
           {pastDueTools.map((tool) => (
             <ListGroup.Item key={tool.id} className="d-flex justify-content-between align-items-center">

--- a/frontend/src/components/dashboard/UserCheckoutStatus.jsx
+++ b/frontend/src/components/dashboard/UserCheckoutStatus.jsx
@@ -75,9 +75,19 @@ const UserCheckoutStatus = () => {
       </Card.Header>
       <Card.Body className="p-0">
         {activeCheckouts.length === 0 ? (
-          <Alert variant="success" className="m-3">
-            You don't have any tools checked out.
-          </Alert>
+          <>
+            <Alert variant="success" className="m-3">
+              You don't have any tools checked out.
+            </Alert>
+            {user?.is_admin && (
+              <Alert variant="info" className="mx-3 mb-3">
+                <small>
+                  <i className="bi bi-info-circle me-1"></i>
+                  As an admin, you can see tools checked out to other users in the "Past Due Tools" section above.
+                </small>
+              </Alert>
+            )}
+          </>
         ) : (
           <ListGroup variant="flush">
             {activeCheckouts.map((checkout) => {


### PR DESCRIPTION
## Description
This PR addresses issue #142 where there was a discrepancy between the dashboard and the My Checkouts page.

## Changes Made
- Added a clarification note to the Past Due Tools section explaining that it shows tools checked out to all users
- Added a note to the My Checked Out Tools section for admin users explaining that they can see tools checked out to other users in the Past Due Tools section

## Testing
- Verified that the dashboard now clearly shows the distinction between tools checked out to the current user and tools checked out to other users
- Confirmed that the My Checkouts page correctly shows the tools checked out to the current user

## Screenshots

## Fixes
Fixes #142

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an informational alert to clarify the purpose of the Past Due Tools section and direct users to their personal checkouts.
  - Admin users now see an additional alert in the User Checkout Status section, guiding them to view all users' checked out tools in the Past Due Tools area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->