### PR TITLE
Fix Calibration Due Soon alert consistency across pages

### DIFF
--- a/frontend/src/components/calibration/CalibrationNotifications.jsx
+++ b/frontend/src/components/calibration/CalibrationNotifications.jsx
@@ -8,25 +8,25 @@ const CalibrationNotifications = () => {
   const dispatch = useDispatch();
   const { calibrationsDue, overdueCalibrations, loading } = useSelector((state) => state.calibration);
   const { user } = useSelector((state) => state.auth);
-  
+
   const [showDueNotification, setShowDueNotification] = useState(true);
   const [showOverdueNotification, setShowOverdueNotification] = useState(true);
-  
+
   // Check if user has permission to see calibration notifications
   const hasPermission = user?.is_admin || user?.department === 'Materials';
-  
+
   useEffect(() => {
     if (hasPermission) {
       dispatch(fetchCalibrationsDue(30)); // Get tools due for calibration in the next 30 days
       dispatch(fetchOverdueCalibrations());
     }
   }, [dispatch, hasPermission]);
-  
+
   // Don't show notifications if user doesn't have permission
   if (!hasPermission) {
     return null;
   }
-  
+
   // Don't show notifications if there are no tools due or overdue for calibration
   if (
     (!calibrationsDue || calibrationsDue.length === 0) &&
@@ -34,13 +34,13 @@ const CalibrationNotifications = () => {
   ) {
     return null;
   }
-  
+
   return (
     <div className="mb-4">
       {showOverdueNotification && overdueCalibrations && overdueCalibrations.length > 0 && (
-        <Alert 
-          variant="danger" 
-          dismissible 
+        <Alert
+          variant="danger"
+          dismissible
           onClose={() => setShowOverdueNotification(false)}
           className="d-flex justify-content-between align-items-center"
         >
@@ -54,7 +54,7 @@ const CalibrationNotifications = () => {
           <div>
             <Button
               as={Link}
-              to="/calibrations"
+              to="/calibrations?tab=overdue"
               variant="outline-danger"
               size="sm"
             >
@@ -63,11 +63,11 @@ const CalibrationNotifications = () => {
           </div>
         </Alert>
       )}
-      
+
       {showDueNotification && calibrationsDue && calibrationsDue.length > 0 && (
-        <Alert 
-          variant="warning" 
-          dismissible 
+        <Alert
+          variant="warning"
+          dismissible
           onClose={() => setShowDueNotification(false)}
           className="d-flex justify-content-between align-items-center"
         >
@@ -80,7 +80,7 @@ const CalibrationNotifications = () => {
           <div>
             <Button
               as={Link}
-              to="/calibrations"
+              to="/calibrations?tab=due"
               variant="outline-warning"
               size="sm"
             >

--- a/frontend/src/pages/CalibrationManagement.jsx
+++ b/frontend/src/pages/CalibrationManagement.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Card, Row, Col, Nav, Tab, Alert, Button } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import CalibrationDueList from '../components/calibration/CalibrationDueList';
 import CalibrationOverdueList from '../components/calibration/CalibrationOverdueList';
 import CalibrationHistoryList from '../components/calibration/CalibrationHistoryList';
@@ -10,7 +10,17 @@ import CalibrationStandardsList from '../components/calibration/CalibrationStand
 const CalibrationManagement = () => {
   const { user } = useSelector((state) => state.auth);
   const isAdmin = user?.is_admin || user?.department === 'Materials';
-  const [activeTab, setActiveTab] = useState('due');
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const tabParam = queryParams.get('tab');
+  const [activeTab, setActiveTab] = useState(tabParam || 'due');
+
+  // Update active tab when URL query parameter changes
+  useEffect(() => {
+    if (tabParam && ['due', 'overdue', 'history', 'standards'].includes(tabParam)) {
+      setActiveTab(tabParam);
+    }
+  }, [tabParam]);
 
   if (!isAdmin) {
     return (

--- a/frontend/src/pages/ToolsManagement.jsx
+++ b/frontend/src/pages/ToolsManagement.jsx
@@ -1,8 +1,7 @@
 import { useSelector } from 'react-redux';
-import { Button, Alert } from 'react-bootstrap';
+import { Button, Alert, Badge } from 'react-bootstrap';
 import { Link, useLocation } from 'react-router-dom';
 import ToolList from '../components/tools/ToolList';
-import CalibrationNotifications from '../components/calibration/CalibrationNotifications';
 
 const ToolsManagement = () => {
   const { user } = useSelector((state) => state.auth);
@@ -24,16 +23,21 @@ const ToolsManagement = () => {
 
       <div className="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-3">
         <h1 className="mb-0">Tool Inventory</h1>
-        {isAdmin && (
-          <Button as={Link} to="/tools/new" variant="success" size="lg">
-            <i className="bi bi-plus-circle me-2"></i>
-            Add New Tool
-          </Button>
-        )}
+        <div className="d-flex gap-2">
+          {isAdmin && (
+            <Button as={Link} to="/calibrations" variant="outline-primary" size="lg">
+              <i className="bi bi-tools me-2"></i>
+              Calibration Management
+            </Button>
+          )}
+          {isAdmin && (
+            <Button as={Link} to="/tools/new" variant="success" size="lg">
+              <i className="bi bi-plus-circle me-2"></i>
+              Add New Tool
+            </Button>
+          )}
+        </div>
       </div>
-
-      {/* Show calibration notifications for admin and Materials department users */}
-      {isAdmin && <CalibrationNotifications />}
 
       <ToolList />
     </div>


### PR DESCRIPTION
## Description

This PR fixes issue #145 by addressing two related problems:

1. The "View Due Tools" button in the Calibration Due Soon alert had inconsistent behavior across different pages
2. The same calibration notifications were appearing in multiple places (Dashboard and Tools page), which could be confusing to users

## Changes Made

### Part 1: Fix inconsistent button behavior

1. Modified the `CalibrationNotifications` component to include query parameters in the links:
   - Added `?tab=due` to the "View Due Tools" button link
   - Added `?tab=overdue` to the "View Overdue Tools" button link

2. Updated the `CalibrationManagement` component to read the query parameter and set the active tab accordingly:
   - Added `useLocation` hook to access URL query parameters
   - Added logic to set the active tab based on the query parameter

### Part 2: Centralize calibration notifications

1. Removed the `CalibrationNotifications` component from the Tools page
2. Added a "Calibration Management" button to the Tools page for admin users to easily access calibration functionality

This approach centralizes all notifications on the Dashboard, which is the most appropriate place for system-wide alerts, while still providing easy access to calibration management from the Tools page.

## Testing

Tested the fix by:
1. Navigating to the Dashboard and clicking the "View Due Tools" button
2. Verifying that the button takes the user to the Calibrations page with the "Due Soon" tab selected
3. Verifying that calibration notifications no longer appear on the Tools page
4. Verifying that the new "Calibration Management" button on the Tools page works correctly

Closes #145