### PR TITLE
Fix CORS defaults for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Backend Environment Variables
 FLASK_ENV=production
 SECRET_KEY=your-secure-secret-key
-CORS_ORIGINS=http://localhost,http://localhost:80
+CORS_ORIGINS=http://localhost:5173,http://localhost,http://localhost:80
 PYTHONDONTWRITEBYTECODE=1
 PYTHONUNBUFFERED=1
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -31,7 +31,7 @@ Edit the `.env` file to set your environment variables:
 # Backend Environment Variables
 FLASK_ENV=production
 SECRET_KEY=your-secure-secret-key
-CORS_ORIGINS=http://localhost,http://localhost:80
+CORS_ORIGINS=http://localhost:5173,http://localhost,http://localhost:80
 PYTHONDONTWRITEBYTECODE=1
 PYTHONUNBUFFERED=1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - FLASK_ENV=${FLASK_ENV:-production}
       - SECRET_KEY=${SECRET_KEY:-production-secret-key-change-me}
-      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost,http://localhost:80}
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5173,http://localhost,http://localhost:80}
       - PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE:-1}
       - PYTHONUNBUFFERED=${PYTHONUNBUFFERED:-1}
     ports:


### PR DESCRIPTION
## Summary
- include port 5173 in default CORS origins in docker-compose
- update env example with same value
- update Docker setup documentation

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_684f0cd052a4832c84a3a7ed92d0a60f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to allow connections from an additional local development origin (`http://localhost:5173`).
	- Updated documentation to reflect the new allowed origin for CORS requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->