### PR TITLE
Automate Cloud SQL initialization

### DIFF
--- a/DEPLOYMENT_GCP.md
+++ b/DEPLOYMENT_GCP.md
@@ -108,11 +108,14 @@ gcloud builds submit --config=cloudbuild.yaml
 
 ### 5. Initialize Database
 
-```bash
-# Connect to Cloud SQL and run initialization
-gcloud sql connect supplyline-db --user=supplyline_user --database=supplyline
+Database initialization is now handled automatically by `deploy-gcp.sh`. After the
+Cloud SQL instance is created, the script invokes `backend/cloud_sql_init.py`
+through the Cloud SQL Auth proxy to create all tables and the default admin user.
 
-# Or use the Cloud SQL Proxy
+If you ever need to run the initialization manually, start the Cloud SQL Proxy and
+execute the script:
+
+```bash
 ./cloud_sql_proxy -instances=PROJECT_ID:REGION:supplyline-db=tcp:5432 &
 python backend/cloud_sql_init.py
 ```


### PR DESCRIPTION
## Summary
- automatically run `backend/cloud_sql_init.py` during deployment
- update docs to describe automated DB initialization

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'Chemical' from 'models')*

------
https://chatgpt.com/codex/tasks/task_e_684f0f9de9cc832cafbae000a50ae57d