### PR TITLE
Enable variable substitution for Cloud Run templates

### DIFF
--- a/DEPLOYMENT_GCP.md
+++ b/DEPLOYMENT_GCP.md
@@ -117,6 +117,24 @@ gcloud sql connect supplyline-db --user=supplyline_user --database=supplyline
 python backend/cloud_sql_init.py
 ```
 
+### 6. Deploy Using Cloud Run Templates
+
+The `cloud-run-backend.yaml` and `cloud-run-frontend.yaml` files contain
+deployment configurations with placeholders for your project and region.
+Use `envsubst` to substitute environment variables and pipe the result to
+`gcloud run services replace`:
+
+```bash
+export PROJECT_ID=<your-gcp-project>
+export REGION=<your-region>
+
+envsubst < cloud-run-backend.yaml | \
+  gcloud run services replace - --region "$REGION" --project "$PROJECT_ID"
+
+envsubst < cloud-run-frontend.yaml | \
+  gcloud run services replace - --region "$REGION" --project "$PROJECT_ID"
+```
+
 ## Configuration
 
 ### Environment Variables

--- a/cloud-run-backend.yaml
+++ b/cloud-run-backend.yaml
@@ -11,14 +11,14 @@ spec:
       annotations:
         run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/execution-environment: gen2
-        run.googleapis.com/vpc-access-connector: projects/PROJECT_ID/locations/REGION/connectors/supplyline-connector
-        run.googleapis.com/cloudsql-instances: PROJECT_ID:REGION:supplyline-db
+        run.googleapis.com/vpc-access-connector: projects/${PROJECT_ID}/locations/${REGION}/connectors/supplyline-connector
+        run.googleapis.com/cloudsql-instances: ${PROJECT_ID}:${REGION}:supplyline-db
     spec:
       containerConcurrency: 100
       timeoutSeconds: 300
-      serviceAccountName: supplyline-backend-sa@PROJECT_ID.iam.gserviceaccount.com
+      serviceAccountName: supplyline-backend-sa@${PROJECT_ID}.iam.gserviceaccount.com
       containers:
-      - image: gcr.io/PROJECT_ID/supplyline-backend:latest
+      - image: gcr.io/${PROJECT_ID}/supplyline-backend:latest
         ports:
         - name: http1
           containerPort: 5000
@@ -31,9 +31,9 @@ spec:
               secret: supplyline-secret-key
               version: 1
         - name: CORS_ORIGINS
-          value: "https://supplyline-frontend-REGION.a.run.app"
+          value: "https://supplyline-frontend-${REGION}.a.run.app"
         - name: DB_HOST
-          value: "/cloudsql/PROJECT_ID:REGION:supplyline-db"
+          value: "/cloudsql/${PROJECT_ID}:${REGION}:supplyline-db"
         - name: DB_USER
           valueSource:
             secretKeyRef:

--- a/cloud-run-frontend.yaml
+++ b/cloud-run-frontend.yaml
@@ -14,15 +14,15 @@ spec:
     spec:
       containerConcurrency: 1000
       timeoutSeconds: 300
-      serviceAccountName: supplyline-frontend-sa@PROJECT_ID.iam.gserviceaccount.com
+      serviceAccountName: supplyline-frontend-sa@${PROJECT_ID}.iam.gserviceaccount.com
       containers:
-      - image: gcr.io/PROJECT_ID/supplyline-frontend:latest
+      - image: gcr.io/${PROJECT_ID}/supplyline-frontend:latest
         ports:
         - name: http1
           containerPort: 80
         env:
         - name: VITE_API_URL
-          value: "https://supplyline-backend-REGION.a.run.app"
+          value: "https://supplyline-backend-${REGION}.a.run.app"
         resources:
           limits:
             cpu: "0.5"


### PR DESCRIPTION
## Summary
- parameterize `cloud-run-backend.yaml` and `cloud-run-frontend.yaml`
- document `gcloud run services replace` usage with `envsubst`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f8feac8832cafccd6b564992102