### PR TITLE
Fix session cookie name for Flask-Session

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,6 +31,9 @@ def create_app():
     )
     app.config.from_object(Config)
 
+    # Set session cookie name explicitly for Flask-Session compatibility
+    app.session_cookie_name = app.config['SESSION_COOKIE_NAME']
+
     # Configure structured logging
     if hasattr(Config, 'LOGGING_CONFIG'):
         try:


### PR DESCRIPTION
## Summary
- set `app.session_cookie_name` from config after creating the Flask app

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: cannot import name 'Chemical', sqlite3 OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684f15cd2384832cb7d1e2fc391ead9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated session cookie name configuration to ensure compatibility with Flask-Session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->