### PR TITLE
Add TestingConfig for in-memory tests

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -207,3 +207,14 @@ class Config:
         'LOCKOUT_MULTIPLIER': int(os.environ.get('LOCKOUT_MULTIPLIER', 2)),  # Multiplier for subsequent lockouts
         'MAX_LOCKOUT_MINUTES': int(os.environ.get('MAX_LOCKOUT_MINUTES', 60))  # Maximum lockout duration in minutes
     }
+
+class TestingConfig(Config):
+    """Configuration for running unit tests."""
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    # Simplified session configuration for tests
+    SESSION_TYPE = 'filesystem'
+    SESSION_FILE_DIR = '/tmp/flask_session_test'
+    SESSION_PERMANENT = False
+    SESSION_USE_SIGNER = False
+

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -1,13 +1,14 @@
 import pytest
 from backend.app import create_app
 from backend.models import db, Tool, User, Checkout, AuditLog
+from backend.config import TestingConfig
 import json
 from datetime import datetime
 
 @pytest.fixture(scope='module')
 def test_app():
     app = create_app()
-    app.config.from_object('backend.config.TestingConfig')
+    app.config.from_object(TestingConfig)
     with app.app_context():
         db.create_all()
         yield app


### PR DESCRIPTION
## Summary
- add `TestingConfig` to simplify DB and session setup for tests
- use new `TestingConfig` in backend API tests

## Testing
- `PYTHONPATH=backend:. pytest tests/backend/test_api.py -q` *(fails: OperationalError - unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_684f15cacdf0832cb695b74d5a9dbc42