### PR TITLE
Update tests for unified auth decorators

### DIFF
--- a/backend/tests/test_cycle_count.py
+++ b/backend/tests/test_cycle_count.py
@@ -13,7 +13,7 @@ from unittest.mock import patch, MagicMock
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from app import app
+from app import create_app
 from models import db, User, Tool, Chemical
 from models_cycle_count import (
     CycleCountSchedule, CycleCountBatch, CycleCountItem,
@@ -26,7 +26,7 @@ class CycleCountTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.app = app
+        self.app = create_app()
         self.app.config['TESTING'] = True
         self.app.config['WTF_CSRF_ENABLED'] = False
 
@@ -88,7 +88,7 @@ class CycleCountTestCase(unittest.TestCase):
 
     def _login(self):
         """Helper method to log in"""
-        return self.client.post('/api/login',
+        return self.client.post('/api/auth/login',
                               data=json.dumps({
                                   'employee_number': 'TEST001',
                                   'password': 'test123'


### PR DESCRIPTION
## Summary
- update cycle count tests to use `create_app`
- verify JWT headers in backend test suite
- add coverage for chemical issuance, cycle counts and announcements

## Testing
- `pytest tests/backend/test_api.py -q`
- `pytest -q` *(fails: fixture errors and database connection failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853a150048c832c81a5839b2c22bffb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to use JWT token-based authentication for improved security.
  - Enhanced test coverage with new tests for chemical issuance, cycle count schedules, and announcement reading endpoints.
  - Adjusted authentication flows and endpoints in test setup to match current application structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->