### PR TITLE
Fix Flask-Session initialization

### DIFF
--- a/DEPLOYMENT_GCP.md
+++ b/DEPLOYMENT_GCP.md
@@ -151,10 +151,20 @@ through the Cloud SQL Auth proxy to create all tables and the default admin user
 If you ever need to run the initialization manually, start the Cloud SQL Proxy and
 execute the script:
 
+
 ```bash
 ./cloud_sql_proxy -instances=PROJECT_ID:REGION:supplyline-db=tcp:5432 &
 python backend/cloud_sql_init.py
 ```
+
+### 8. Create Sessions Table
+
+After the database is initialized, create the table used by Flask-Session:
+
+```bash
+curl -X POST "$BACKEND_URL/api/create-sessions-table"
+```
+
 
 ### 6. Deploy Using Cloud Run Templates
 

--- a/backend/tests/test_cycle_count.py
+++ b/backend/tests/test_cycle_count.py
@@ -13,7 +13,8 @@ from unittest.mock import patch, MagicMock
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from app import app
+from app import create_app
+app = create_app()
 from models import db, User, Tool, Chemical
 from models_cycle_count import (
     CycleCountSchedule, CycleCountBatch, CycleCountItem,


### PR DESCRIPTION
## Summary
- initialize Flask-Session when running in Cloud Run
- document creating the sessions table
- adjust cycle count tests to create the app instance

## Testing
- `pytest -q tests/backend/test_api.py` *(fails: assert 401 == 201)*

------
https://chatgpt.com/codex/tasks/task_e_6853a14f25a4832cacaf724f82d7c7c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment guide to include instructions for creating the sessions table via a backend API endpoint.

- **Bug Fixes**
  - Improved session configuration to conditionally initialize Flask-Session with an SQL backend only when appropriate, enhancing reliability in different environments.

- **Tests**
  - Updated test setup to use a dynamic app factory for initializing the Flask application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->