### PR TITLE
Add error handling Playwright tests

### DIFF
--- a/frontend/tests/e2e/error-handling/404-and-errors.spec.js
+++ b/frontend/tests/e2e/error-handling/404-and-errors.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../utils/auth-helpers.js';
+import { navigateToPage, waitForLoadingToComplete, takeScreenshot } from '../utils/test-helpers.js';
+
+test.describe('Error Handling', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('should display 404 page for invalid URL', async ({ page }) => {
+    await page.goto('/non-existent-page');
+    await waitForLoadingToComplete(page);
+    await expect(page.locator('body')).toContainText(/404|not found/i);
+    await takeScreenshot(page, '404-page');
+  });
+
+  test('should show error message when API request fails', async ({ page }) => {
+    await page.route('**/api/tools', route => {
+      route.abort('failed');
+    });
+
+    await navigateToPage(page, '/tools');
+    await expect(page.locator('.alert-danger, .error-message')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add E2E tests for 404 and failed API calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4a12884832c95b220760aef3043