### PR TITLE
Fix CORS configuration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -59,9 +59,10 @@ def create_app():
     # ``Access-Control-Allow-Origin`` header, causing the frontend to report a
     # CORS error.  Expanding the resource pattern ensures the middleware runs
     # for every request path.
+    # Use custom origin validation function for dynamic pattern matching
     CORS(app, resources={
         r"/*": {
-            "origins": allowed_origins,
+            "origins": Config.validate_cors_origin,
             "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
             "allow_headers": ["Content-Type", "Authorization", "X-CSRF-Token"],
             "supports_credentials": True,

--- a/backend/config.py
+++ b/backend/config.py
@@ -216,7 +216,8 @@ class Config:
             # Support multiple common Cloud Run URL patterns
             return [
                 'https://supplyline-frontend-production-454313121816.us-west1.run.app',
-                'https://supplyline-frontend-*.a.run.app'
+                # Use a regex pattern to match any dynamically generated frontend URL on Cloud Run
+                r'https://supplyline-frontend-.*\.a\.run\.app'
             ]
         else:
             # Development defaults

--- a/backend/config.py
+++ b/backend/config.py
@@ -216,8 +216,7 @@ class Config:
             # Support multiple common Cloud Run URL patterns
             return [
                 'https://supplyline-frontend-production-454313121816.us-west1.run.app',
-                # Use a regex pattern to match any dynamically generated frontend URL on Cloud Run
-                r'https://supplyline-frontend-.*\.a\.run\.app'
+                # Additional known production URLs can be added here
             ]
         else:
             # Development defaults
@@ -229,6 +228,30 @@ class Config:
                 'http://192.168.1.122:5173',
                 'http://100.108.111.69:5173'
             ]
+
+    @staticmethod
+    def validate_cors_origin(origin):
+        """
+        Custom CORS origin validation function that supports regex patterns.
+        This function is used by Flask-CORS to validate incoming origins.
+        """
+        import re
+
+        # Get the static origins list
+        static_origins = Config.get_cors_origins()
+
+        # Check if origin is in the static list
+        if origin in static_origins:
+            return True
+
+        # For production, also check dynamic Cloud Run URL patterns
+        if os.environ.get('FLASK_ENV') == 'production':
+            # Allow any supplyline-frontend URL on Cloud Run's a.run.app domain
+            cloud_run_pattern = r'https://supplyline-frontend-.*\.a\.run\.app'
+            if re.match(cloud_run_pattern, origin):
+                return True
+
+        return False
 
     CORS_ORIGINS = get_cors_origins()
     CORS_SUPPORTS_CREDENTIALS = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ reportlab==4.0.4
 openpyxl==3.1.2
 pytest==8.3.5
 pytest-flask==1.3.0
+requests==2.31.0
 # PostgreSQL support for Cloud SQL (using psycopg 3.x for Python 3.13 compatibility)
 psycopg[binary]==3.2.9
 # Cloud SQL Python Connector (optional, for IAM authentication)

--- a/backend/tests/test_cycle_count.py
+++ b/backend/tests/test_cycle_count.py
@@ -11,7 +11,10 @@ from unittest.mock import patch, MagicMock
 
 # Import the Flask app and models
 import sys
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add the project root to the path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+# Add the backend directory to the path for models import
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'backend'))
 
 from app import create_app
 from models import db, User, Tool, Chemical
@@ -75,6 +78,7 @@ class CycleCountTestCase(unittest.TestCase):
         # Create test chemical
         self.test_chemical = Chemical(
             part_number='C001',
+            lot_number='L001',  # Required field
             description='Test Chemical',
             category='Testing',
             quantity=100.0,

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,7 +43,8 @@ steps:
       - '--max-instances'
       - '10'
       - '--set-env-vars'
-      - 'FLASK_ENV=production,DB_HOST=/cloudsql/$PROJECT_ID:us-west1:supplyline-db,DB_USER=supplyline_user,DB_NAME=supplyline,PYTHONDONTWRITEBYTECODE=1,PYTHONUNBUFFERED=1,CORS_ORIGINS=*'
+      # Explicit origin to avoid wildcard CORS in production deployments
+      - 'FLASK_ENV=production,DB_HOST=/cloudsql/$PROJECT_ID:us-west1:supplyline-db,DB_USER=supplyline_user,DB_NAME=supplyline,PYTHONDONTWRITEBYTECODE=1,PYTHONUNBUFFERED=1,CORS_ORIGINS=https://supplyline-frontend-production-454313121816.us-west1.run.app'
       - '--set-secrets'
       - 'SECRET_KEY=supplyline-secret-key:latest,DB_PASSWORD=supplyline-db-password:latest'
       - '--set-cloudsql-instances'


### PR DESCRIPTION
## Summary
- tighten Cloud Build environment CORS_ORIGINS to specific frontend URL
- use regex pattern for dynamic frontend domains in default config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685466397338832ca703b7aa37c88699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CORS configuration to dynamically validate allowed frontend URLs in production using pattern matching.
  - Restricted allowed CORS origins in production deployments to a specific frontend URL for enhanced security.
  - Added clarification comments regarding CORS origin settings in deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->