### PR TITLE
Clean up session settings

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,9 +12,9 @@
    ```
    pip install -r requirements.txt
    ```
-3. Create the database and flask_session directories if they don't exist:
+3. Create the database directory if it doesn't exist:
    ```
-   mkdir -p ../database ../flask_session
+   mkdir -p ../database
    ```
 4. Run the backend server:
    ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -43,14 +43,23 @@ def create_app():
 
     # Initialize CORS with settings from config
     allowed_origins = app.config.get('CORS_ORIGINS', ['http://localhost:5173'])
-    CORS(app, resources={
-        r"/api/*": {
-            "origins": allowed_origins,
-            "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-            "allow_headers": ["Content-Type", "Authorization", "X-CSRF-Token"],
-            "supports_credentials": True
-        }
-    })
+    allow_headers = app.config.get('CORS_ALLOW_HEADERS', [
+        "Content-Type",
+        "Authorization",
+        "X-CSRF-Token",
+    ])
+    supports_credentials = app.config.get('CORS_SUPPORTS_CREDENTIALS', False)
+    CORS(
+        app,
+        resources={
+            r"/api/*": {
+                "origins": allowed_origins,
+                "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+                "allow_headers": allow_headers,
+                "supports_credentials": supports_credentials,
+            }
+        },
+    )
 
     # Initialize Flask-Session
     Session(app)

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,6 +7,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     # Use environment variables with fallbacks for local development
     SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', SECRET_KEY)
 
     # SQLite database path - using absolute path from project root
     # Check if we're in Docker environment (look for /database volume)
@@ -27,21 +28,6 @@ class Config:
 
     # Session configuration - Enhanced security
     PERMANENT_SESSION_LIFETIME = timedelta(hours=8)  # Shorter timeout for security
-    SESSION_TYPE = 'filesystem'
-    # Check if we're in Docker environment (look for /flask_session volume)
-    if os.path.exists('/flask_session'):
-        SESSION_FILE_DIR = '/flask_session'
-    else:
-        SESSION_FILE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'flask_session'))
-    print(f"Using session directory: {SESSION_FILE_DIR}")
-
-    # Session cleanup configuration
-    SESSION_CLEANUP_INTERVAL = 3600  # 1 hour
-    SESSION_MAX_AGE = 86400  # 24 hours
-
-    # Enhanced cookie settings
-    SESSION_COOKIE_SECURE = False  # Set to True only in HTTPS production
-    SESSION_COOKIE_HTTPONLY = True  # Prevent XSS
 
     # Structured logging configuration
     LOGGING_CONFIG = {
@@ -95,16 +81,11 @@ class Config:
         'open_files': 1000,
         'db_connections': 8  # 80% of pool size
     }
-    SESSION_COOKIE_SAMESITE = 'Lax'  # Allow cross-site requests for mobile
-    SESSION_USE_SIGNER = True  # Sign cookies
-    SESSION_COOKIE_NAME = 'supplyline_session'  # Custom name
-
-    # Session security options
-    SESSION_VALIDATE_IP = os.environ.get('SESSION_VALIDATE_IP', 'false').lower() == 'true'
 
     # CORS settings - more restrictive in production
     CORS_ORIGINS = os.environ.get('CORS_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173,http://192.168.1.122:5173,http://100.108.111.69:5173').split(',')
-    CORS_SUPPORTS_CREDENTIALS = True
+    CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'X-CSRF-Token']
+    CORS_SUPPORTS_CREDENTIALS = False
 
     # Additional security headers
     SECURITY_HEADERS = {


### PR DESCRIPTION
## Summary
- simplify backend configuration and remove filesystem session settings
- add a `JWT_SECRET_KEY` option
- tweak CORS setup to use configured headers without credentials
- update backend setup steps in README

## Testing
- `python -m py_compile backend/config.py backend/app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858d363f110832c90c8232a814fe637