### PR TITLE
Update documentation for JWT auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,7 +222,7 @@ This is a major architectural release that migrates the SupplyLine MRO Suite to 
 - Restructured backend API for registration management
 
 ### Fixed
-- Fixed issues with user authentication and session management
+ - Fixed issues with user authentication
 - Improved error handling for registration and authentication processes
 
 ## [2.4.0] - 2025-06-05
@@ -323,7 +323,7 @@ This is a major architectural release that migrates the SupplyLine MRO Suite to 
 
 ### Fixed
 - Fixed Docker database path handling to correctly access the SQLite database in the Docker container
-- Updated Docker volume paths for database and session directories
+ - Updated Docker volume paths for database directory
 - Fixed configuration to properly detect Docker environment
 
 ## [1.1.0] - 2025-05-01

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -142,7 +142,6 @@ The update process includes:
 The application uses Docker volumes to persist data:
 
 - `database`: Stores the SQLite database file
-- `flask_session`: Stores Flask session data
 
 These volumes ensure your data is preserved even when containers are restarted or rebuilt.
 
@@ -188,7 +187,6 @@ If you encounter permission issues:
 1. Check the ownership of the mounted volumes:
    ```bash
    docker-compose exec backend ls -la /database
-   docker-compose exec backend ls -la /flask_session
    ```
 
 2. Verify that the application has write access to the necessary directories:

--- a/README.md
+++ b/README.md
@@ -584,7 +584,6 @@ supplyline-mro-suite/
 │   └── nginx.conf                # Nginx configuration for production
 ├── database/                     # SQLite database
 │   └── tools.db                  # Main database file
-├── flask_session/                # Flask session files
 ├── docker-compose.yml            # Docker Compose configuration
 ├── .env.example                  # Example environment variables
 ├── DOCKER_README.md              # Docker deployment instructions

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 ## What's New in 3.2.0
 - Admin dashboard registration requests are now fully connected to the backend API.
 - Approve and deny registration requests from the dashboard with live updates.
-- Improved backend startup reliability (database/session directory checks).
+- Improved backend startup reliability (database directory checks).
 
 ## Setup and Running
 
@@ -12,9 +12,9 @@
    ```
    pip install -r requirements.txt
    ```
-3. Create the database and flask_session directories if they don't exist:
+3. Create the database directory if it doesn't exist:
    ```
-   mkdir -p ../database ../flask_session
+   mkdir -p ../database
    ```
 4. Run the backend server:
    ```

--- a/docs/technical/cycle-count-technical-guide.md
+++ b/docs/technical/cycle-count-technical-guide.md
@@ -29,7 +29,7 @@ Frontend (React/Redux) ↔ Backend (Flask/SQLAlchemy) ↔ Database (SQLite)
 #### Backend Stack
 - **Flask 2.2**: Web framework
 - **SQLAlchemy 1.4**: ORM
-- **Flask-Session**: Session management
+- **PyJWT**: JWT authentication
 - **Flask-CORS**: Cross-origin requests
 
 #### Database
@@ -159,7 +159,7 @@ CREATE INDEX idx_cycle_count_results_discrepancy ON cycle_count_results(has_disc
 ## API Documentation
 
 ### Authentication
-All API endpoints require authentication via session cookies.
+All API endpoints require authentication via JWT tokens provided in the Authorization header.
 
 ```python
 @require_auth
@@ -438,7 +438,7 @@ export const selectBatchItems = (batchId) => createSelector(
 ## Security Implementation
 
 ### Authentication & Authorization
-- **Session-based Auth**: Secure session management
+- **JWT-Based Auth**: Stateless authentication using access and refresh tokens
 - **Role-based Access**: Different permissions by user role
 - **CSRF Protection**: Cross-site request forgery prevention
 - **Input Validation**: Comprehensive input sanitization


### PR DESCRIPTION
## Summary
- clarify JWT-based authentication in cycle count guide
- remove flask_session folder references from README docs
- clean up CHANGELOG entries mentioning session management

## Testing
- `python -m pytest tests/ -v --maxfail=1 --disable-warnings` *(fails: ModuleNotFoundError: No module named 'routes')*

------
https://chatgpt.com/codex/tasks/task_e_6858d3663188832caac62e557ed6e71a