### PR TITLE
Switch frontend auth to JWT tokens

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -12,14 +12,15 @@ const ProtectedRoute = ({ children, requireAdmin = false }) => {
 
   useEffect(() => {
     const checkAuth = async () => {
-      if (!isAuthenticated && !user) {
+      const token = localStorage.getItem('access_token');
+      if (token && !user) {
         await dispatch(fetchCurrentUser());
       }
       setIsChecking(false);
     };
 
     checkAuth();
-  }, [dispatch, isAuthenticated, user]);
+  }, [dispatch, user]);
 
   if (loading || isChecking) {
     return (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,13 +6,16 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // Important for cookies/session
+  withCredentials: false, // JWT auth doesn't rely on cookies
 });
 
 // Request interceptor for adding auth token
 api.interceptors.request.use(
   (config) => {
-    // You could add auth token here if using JWT
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
     // Only log non-GET requests in development environment or when debugging is enabled
     if (config.method.toUpperCase() !== 'GET' &&
         (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')) {

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,14 +1,22 @@
 import api from './api';
 
+const TOKEN_KEY = 'access_token';
+const REFRESH_KEY = 'refresh_token';
+
 const AuthService = {
-  // Login user
+  // Login user and store tokens
   login: async (username, password) => {
     try {
       const response = await api.post('/auth/login', {
         employee_number: username,
-        password
+        password,
       });
-      return response.data;
+
+      const { access_token, refresh_token, user } = response.data;
+      localStorage.setItem(TOKEN_KEY, access_token);
+      localStorage.setItem(REFRESH_KEY, refresh_token);
+
+      return { user, access_token, refresh_token };
     } catch (error) {
       throw error;
     }
@@ -31,28 +39,38 @@ const AuthService = {
       return response.data;
     } catch (error) {
       throw error;
+    } finally {
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(REFRESH_KEY);
+    }
+  },
+
+  // Refresh access token using refresh token
+  refreshToken: async () => {
+    try {
+      const refresh_token = localStorage.getItem(REFRESH_KEY);
+      if (!refresh_token) {
+        throw new Error('No refresh token available');
+      }
+      const response = await api.post('/auth/refresh', { refresh_token });
+      const { access_token, refresh_token: new_refresh } = response.data;
+      localStorage.setItem(TOKEN_KEY, access_token);
+      localStorage.setItem(REFRESH_KEY, new_refresh);
+      return { access_token, refresh_token: new_refresh };
+    } catch (error) {
+      throw error;
     }
   },
 
   // Get current user info
   getCurrentUser: async () => {
     try {
-      const response = await api.get('/auth/user');
-      return response.data;
+      const response = await api.get('/auth/me');
+      return response.data.user;
     } catch (error) {
       throw error;
     }
   },
-
-  // Check if user is authenticated
-  isAuthenticated: async () => {
-    try {
-      const response = await api.get('/auth/status');
-      return response.data.authenticated;
-    } catch (error) {
-      return false;
-    }
-  }
 };
 
 export default AuthService;


### PR DESCRIPTION
## Summary
- store JWT tokens on login and send in API headers
- refresh tokens with `/api/auth/refresh`
- read tokens from storage when initializing auth state
- load user using new `/api/auth/me` endpoint
- adjust ProtectedRoute to check tokens

## Testing
- `npm run lint` *(fails: cannot find global definitions and other lint errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858d3653560832caa26a50cc6914423