### PR TITLE
Remove remember token support

### DIFF
--- a/backend/migrations/remove_remember_token.py
+++ b/backend/migrations/remove_remember_token.py
@@ -1,0 +1,37 @@
+"""Migration script to drop remember_token columns from users table"""
+import sqlite3
+import os
+
+
+def run_migration():
+    db_path = os.path.join('database', 'tools.db')
+    if not os.path.exists(db_path):
+        print(f"Database not found at {db_path}")
+        return False
+
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        cursor.execute("PRAGMA table_info(users)")
+        columns = [c[1] for c in cursor.fetchall()]
+        altered = False
+        if 'remember_token' in columns:
+            cursor.execute("ALTER TABLE users DROP COLUMN remember_token")
+            altered = True
+            print("Dropped remember_token column")
+        if 'remember_token_expiry' in columns:
+            cursor.execute("ALTER TABLE users DROP COLUMN remember_token_expiry")
+            altered = True
+            print("Dropped remember_token_expiry column")
+        if altered:
+            conn.commit()
+        conn.close()
+        return True
+    except Exception as e:
+        print(f"Error during migration: {e}")
+        return False
+
+
+if __name__ == '__main__':
+    run_migration()

--- a/backend/models.py
+++ b/backend/models.py
@@ -87,8 +87,6 @@ class User(db.Model):
     created_at = db.Column(db.DateTime, default=get_current_time)
     reset_token = db.Column(db.String, nullable=True)
     reset_token_expiry = db.Column(db.DateTime, nullable=True)
-    remember_token = db.Column(db.String, nullable=True)
-    remember_token_expiry = db.Column(db.DateTime, nullable=True)
     avatar = db.Column(db.String, nullable=True)  # Store the path or URL to the avatar image
     # Account lockout fields
     failed_login_attempts = db.Column(db.Integer, default=0)
@@ -125,23 +123,6 @@ class User(db.Model):
         self.reset_token = None
         self.reset_token_expiry = None
 
-    def generate_remember_token(self):
-        import secrets
-        token = secrets.token_hex(32)
-        self.remember_token = generate_password_hash(token)
-        self.remember_token_expiry = get_current_time() + timedelta(days=30)  # Valid for 30 days
-        return token
-
-    def check_remember_token(self, token):
-        if not self.remember_token or not self.remember_token_expiry:
-            return False
-        if get_current_time() > self.remember_token_expiry:
-            return False
-        return check_password_hash(self.remember_token, token)
-
-    def clear_remember_token(self):
-        self.remember_token = None
-        self.remember_token_expiry = None
 
     def has_role(self, role_name):
         """Check if user has a specific role by name"""

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -79,33 +79,6 @@ class TestUserModel:
         assert user.reset_token is None
         assert user.reset_token_expiry is None
     
-    def test_user_remember_token(self, db_session):
-        """Test remember me token functionality"""
-        user = User(
-            name='Remember Test',
-            employee_number='REMEMBER001',
-            department='Testing'
-        )
-        user.set_password('test123')
-        db_session.add(user)
-        db_session.commit()
-        
-        # Generate remember token
-        token = user.generate_remember_token()
-        
-        assert token is not None
-        assert len(token) == 64  # 32 bytes hex = 64 chars
-        assert user.remember_token is not None
-        assert user.remember_token_expiry is not None
-        
-        # Verify token
-        assert user.check_remember_token(token)
-        assert not user.check_remember_token('invalid_token')
-        
-        # Clear token
-        user.clear_remember_token()
-        assert user.remember_token is None
-        assert user.remember_token_expiry is None
     
     def test_user_account_lockout(self, db_session):
         """Test account lockout functionality"""

--- a/init_db.py
+++ b/init_db.py
@@ -25,8 +25,6 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     reset_token TEXT,
     reset_token_expiry TIMESTAMP,
-    remember_token TEXT,
-    remember_token_expiry TIMESTAMP
 )
 ''')
 


### PR DESCRIPTION
## Summary
- drop remember_token fields and related methods in models
- strip remember me cookie handling from auth routes
- update init_db script
- add migration to drop remember_token columns
- clean up tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858d3649714832c8dd1b49fdc5f7031