### PR TITLE
Update auth service token handling

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -12,10 +12,15 @@ const api = axios.create({
 // Request interceptor for adding auth token
 api.interceptors.request.use(
   (config) => {
-    // You could add auth token here if using JWT
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     // Only log non-GET requests in development environment or when debugging is enabled
-    if (config.method.toUpperCase() !== 'GET' &&
-        (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')) {
+    if (
+      config.method.toUpperCase() !== 'GET' &&
+      (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')
+    ) {
       console.log(`API Request [${config.method.toUpperCase()}] ${config.url}:`, config.data);
     }
     return config;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,14 +1,35 @@
 import api from './api';
 
+const decodeToken = (token) => {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => `%${('00' + c.charCodeAt(0).toString(16)).slice(-2)}`)
+        .join('')
+    );
+    return JSON.parse(jsonPayload);
+  } catch (e) {
+    return null;
+  }
+};
+
 const AuthService = {
   // Login user
   login: async (username, password) => {
     try {
       const response = await api.post('/auth/login', {
         employee_number: username,
-        password
+        password,
       });
-      return response.data;
+
+      const { access_token, refresh_token, user } = response.data;
+      localStorage.setItem('access_token', access_token);
+      localStorage.setItem('refresh_token', refresh_token);
+      localStorage.setItem('user', JSON.stringify(user));
+      return user;
     } catch (error) {
       throw error;
     }
@@ -24,34 +45,54 @@ const AuthService = {
     }
   },
 
+  // Refresh JWT tokens using refresh token from storage
+  refreshToken: async () => {
+    const refresh_token = localStorage.getItem('refresh_token');
+    if (!refresh_token) {
+      throw new Error('No refresh token');
+    }
+    const response = await api.post('/auth/refresh', { refresh_token });
+    const { access_token, refresh_token: newRefresh } = response.data;
+    localStorage.setItem('access_token', access_token);
+    localStorage.setItem('refresh_token', newRefresh);
+    return response.data;
+  },
+
   // Logout user
   logout: async () => {
     try {
-      const response = await api.post('/auth/logout');
-      return response.data;
+      await api.post('/auth/logout');
     } catch (error) {
-      throw error;
+      // Ignore logout errors
+    } finally {
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('refresh_token');
+      localStorage.removeItem('user');
     }
   },
 
-  // Get current user info
+  // Get current user info from API or localStorage
   getCurrentUser: async () => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      return JSON.parse(stored);
+    }
     try {
-      const response = await api.get('/auth/user');
-      return response.data;
+      const response = await api.get('/auth/me');
+      const user = response.data.user || response.data;
+      localStorage.setItem('user', JSON.stringify(user));
+      return user;
     } catch (error) {
       throw error;
     }
   },
 
-  // Check if user is authenticated
-  isAuthenticated: async () => {
-    try {
-      const response = await api.get('/auth/status');
-      return response.data.authenticated;
-    } catch (error) {
-      return false;
-    }
+  // Check if user is authenticated by decoding token
+  isAuthenticated: () => {
+    const token = localStorage.getItem('access_token');
+    if (!token) return false;
+    const payload = decodeToken(token);
+    return payload ? payload.exp * 1000 > Date.now() : false;
   }
 };
 


### PR DESCRIPTION
## Summary
- persist auth tokens and user object in browser storage
- send access token in Axios interceptor
- add token refresh and update logout logic
- fetch `/auth/me` for current user

## Testing
- `npm run lint` *(fails: many lint errors)*
- `python -m pytest tests/test_auth.py::TestJWTAuthentication::test_login_success -q` *(fails: TypeError in create_app)*

------
https://chatgpt.com/codex/tasks/task_e_6858d54de664832caf173a4249a78893