### PR TITLE
Add token storage and refresh logic

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -12,7 +12,10 @@ const api = axios.create({
 // Request interceptor for adding auth token
 api.interceptors.request.use(
   (config) => {
-    // You could add auth token here if using JWT
+    const token = localStorage.getItem('supplyline_access_token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     // Only log non-GET requests in development environment or when debugging is enabled
     if (config.method.toUpperCase() !== 'GET' &&
         (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')) {

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -37,7 +37,17 @@ const AuthService = {
   // Get current user info
   getCurrentUser: async () => {
     try {
-      const response = await api.get('/auth/user');
+      const response = await api.get('/auth/me');
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  },
+
+  // Refresh access token using refresh token
+  refreshToken: async (refreshToken) => {
+    try {
+      const response = await api.post('/auth/refresh', { refresh_token: refreshToken });
       return response.data;
     } catch (error) {
       throw error;


### PR DESCRIPTION
## Summary
- read JWT tokens from localStorage when initializing auth state
- refresh access token using `AuthService.refreshToken`
- persist tokens on login and clear on logout
- attach the access token in axios requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858d54e9dc0832cbb73592cdf1a0353