### PR TITLE
Fix protected route token checks

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -5,21 +5,22 @@ import { fetchCurrentUser } from '../../store/authSlice';
 import { Spinner } from 'react-bootstrap';
 
 const ProtectedRoute = ({ children, requireAdmin = false }) => {
-  const { isAuthenticated, loading, user } = useSelector((state) => state.auth);
+  const { accessToken, loading, user } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const location = useLocation();
   const [isChecking, setIsChecking] = useState(true);
 
   useEffect(() => {
     const checkAuth = async () => {
-      if (!isAuthenticated && !user) {
+      const token = accessToken || localStorage.getItem('supplyline_access_token');
+      if (token && !user) {
         await dispatch(fetchCurrentUser());
       }
       setIsChecking(false);
     };
 
     checkAuth();
-  }, [dispatch, isAuthenticated, user]);
+  }, [dispatch, accessToken, user]);
 
   if (loading || isChecking) {
     return (
@@ -31,7 +32,9 @@ const ProtectedRoute = ({ children, requireAdmin = false }) => {
     );
   }
 
-  if (!isAuthenticated) {
+  const token = accessToken || localStorage.getItem('supplyline_access_token');
+
+  if (!token) {
     // Redirect to login page but save the location they were trying to access
     return <Navigate to="/login" state={{ from: location }} replace />;
   }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,13 +6,16 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // Important for cookies/session
 });
 
 // Request interceptor for adding auth token
 api.interceptors.request.use(
   (config) => {
-    // You could add auth token here if using JWT
+    const token = localStorage.getItem('supplyline_access_token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+
     // Only log non-GET requests in development environment or when debugging is enabled
     if (config.method.toUpperCase() !== 'GET' &&
         (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')) {


### PR DESCRIPTION
## Summary
- rely on JWT tokens for auth state
- store tokens in Redux and localStorage
- update Axios to attach Authorization header
- check access token in ProtectedRoute

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6858d54f4284832c879c73d73eec8128