### PR TITLE
Remove flask_session setup and update docs

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -142,7 +142,6 @@ The update process includes:
 The application uses Docker volumes to persist data:
 
 - `database`: Stores the SQLite database file
-- `flask_session`: Stores Flask session data
 
 These volumes ensure your data is preserved even when containers are restarted or rebuilt.
 
@@ -188,7 +187,6 @@ If you encounter permission issues:
 1. Check the ownership of the mounted volumes:
    ```bash
    docker-compose exec backend ls -la /database
-   docker-compose exec backend ls -la /flask_session
    ```
 
 2. Verify that the application has write access to the necessary directories:

--- a/README.md
+++ b/README.md
@@ -584,7 +584,6 @@ supplyline-mro-suite/
 │   └── nginx.conf                # Nginx configuration for production
 ├── database/                     # SQLite database
 │   └── tools.db                  # Main database file
-├── flask_session/                # Flask session files
 ├── docker-compose.yml            # Docker Compose configuration
 ├── .env.example                  # Example environment variables
 ├── DOCKER_README.md              # Docker deployment instructions

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,8 +27,8 @@ RUN pip install --upgrade pip && \
 COPY . .
 
 # Create necessary directories and set permissions
-RUN mkdir -p /database /flask_session && \
-    chown -R appuser:appuser /app /database /flask_session
+RUN mkdir -p /database && \
+    chown -R appuser:appuser /app /database
 
 # Switch to non-root user
 USER appuser

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 ## What's New in 3.2.0
 - Admin dashboard registration requests are now fully connected to the backend API.
 - Approve and deny registration requests from the dashboard with live updates.
-- Improved backend startup reliability (database/session directory checks).
+- Improved backend startup reliability (database directory checks).
 
 ## Setup and Running
 
@@ -11,10 +11,6 @@
 2. Install the required dependencies:
    ```
    pip install -r requirements.txt
-   ```
-3. Create the database and flask_session directories if they don't exist:
-   ```
-   mkdir -p ../database ../flask_session
    ```
 4. Run the backend server:
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     restart: unless-stopped
     volumes:
       - database:/database
-      - flask_session:/flask_session
       - ./update_tools_schema.py:/app/update_tools_schema.py
       - ./backend/migrate_chemicals.py:/app/migrate_chemicals.py
       - ./backend/migrate_tool_calibration.py:/app/migrate_tool_calibration.py
@@ -71,5 +70,3 @@ networks:
 volumes:
   database:
     name: supplyline-database
-  flask_session:
-    name: supplyline-flask-session

--- a/docs/technical/cycle-count-technical-guide.md
+++ b/docs/technical/cycle-count-technical-guide.md
@@ -159,7 +159,7 @@ CREATE INDEX idx_cycle_count_results_discrepancy ON cycle_count_results(has_disc
 ## API Documentation
 
 ### Authentication
-All API endpoints require authentication via session cookies.
+All API endpoints require a valid JWT passed in the `Authorization` header.
 
 ```python
 @require_auth
@@ -438,7 +438,7 @@ export const selectBatchItems = (batchId) => createSelector(
 ## Security Implementation
 
 ### Authentication & Authorization
-- **Session-based Auth**: Secure session management
+- **JWT Auth**: Stateless token-based authentication
 - **Role-based Access**: Different permissions by user role
 - **CSRF Protection**: Cross-site request forgery prevention
 - **Input Validation**: Comprehensive input sanitization

--- a/start_dev_servers.bat
+++ b/start_dev_servers.bat
@@ -29,12 +29,6 @@ if not exist "%PROJECT_ROOT%database" (
     mkdir "%PROJECT_ROOT%database"
 )
 
-REM Create flask_session directory if it doesn't exist
-if not exist "%PROJECT_ROOT%flask_session" (
-    echo Creating flask_session directory...
-    mkdir "%PROJECT_ROOT%flask_session"
-)
-
 echo Starting backend server...
 start cmd /k "cd /d %PROJECT_ROOT%backend && echo Activating virtual environment if it exists... && (if exist venv\Scripts\activate.bat (call venv\Scripts\activate.bat) else (echo No virtual environment found, continuing without it...)) && echo Installing backend dependencies... && pip install -r requirements.txt && echo Starting Flask server... && python run.py"
 

--- a/start_dev_servers.sh
+++ b/start_dev_servers.sh
@@ -29,12 +29,6 @@ if [ ! -d "$PROJECT_ROOT/database" ]; then
     mkdir -p "$PROJECT_ROOT/database"
 fi
 
-# Create flask_session directory if it doesn't exist
-if [ ! -d "$PROJECT_ROOT/flask_session" ]; then
-    echo "Creating flask_session directory..."
-    mkdir -p "$PROJECT_ROOT/flask_session"
-fi
-
 # Start backend server in a new terminal
 echo "Starting backend server..."
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Summary
- remove references to `flask_session` directories from documentation
- drop session directory creation commands in dev scripts
- remove flask_session volume from Docker setup
- update backend Dockerfile accordingly
- document JWT auth in cycle count guide

## Testing
- `pip install -r backend/requirements.txt`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6858d5533208832cbd1a7c3a2374547b