### PR TITLE
Remove remember token columns

### DIFF
--- a/backend/migrations/remove_remember_token_columns.py
+++ b/backend/migrations/remove_remember_token_columns.py
@@ -1,0 +1,51 @@
+import sqlite3
+import os
+
+
+def run_migration():
+    """Remove remember_token columns from users table"""
+    # Determine database path
+    possible_paths = [
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), 'app.db'),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), 'database.db'),
+        os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'database', 'tools.db')
+    ]
+
+    db_path = None
+    for path in possible_paths:
+        if os.path.exists(path):
+            db_path = path
+            print(f"Found database at: {db_path}")
+            break
+
+    if not db_path:
+        raise FileNotFoundError("Could not find the database file")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("PRAGMA table_info(users)")
+    columns = cursor.fetchall()
+    column_names = [c[1] for c in columns]
+
+    version = sqlite3.sqlite_version_info
+
+    try:
+        if version >= (3, 35, 0):
+            if 'remember_token' in column_names:
+                cursor.execute("ALTER TABLE users DROP COLUMN remember_token")
+                print("Dropped column remember_token")
+            if 'remember_token_expiry' in column_names:
+                cursor.execute("ALTER TABLE users DROP COLUMN remember_token_expiry")
+                print("Dropped column remember_token_expiry")
+            conn.commit()
+        else:
+            print("SQLite version too old for DROP COLUMN. Manual migration required.")
+            return False
+    finally:
+        conn.close()
+    return True
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/models.py
+++ b/backend/models.py
@@ -87,8 +87,6 @@ class User(db.Model):
     created_at = db.Column(db.DateTime, default=get_current_time)
     reset_token = db.Column(db.String, nullable=True)
     reset_token_expiry = db.Column(db.DateTime, nullable=True)
-    remember_token = db.Column(db.String, nullable=True)
-    remember_token_expiry = db.Column(db.DateTime, nullable=True)
     avatar = db.Column(db.String, nullable=True)  # Store the path or URL to the avatar image
     # Account lockout fields
     failed_login_attempts = db.Column(db.Integer, default=0)
@@ -125,23 +123,6 @@ class User(db.Model):
         self.reset_token = None
         self.reset_token_expiry = None
 
-    def generate_remember_token(self):
-        import secrets
-        token = secrets.token_hex(32)
-        self.remember_token = generate_password_hash(token)
-        self.remember_token_expiry = get_current_time() + timedelta(days=30)  # Valid for 30 days
-        return token
-
-    def check_remember_token(self, token):
-        if not self.remember_token or not self.remember_token_expiry:
-            return False
-        if get_current_time() > self.remember_token_expiry:
-            return False
-        return check_password_hash(self.remember_token, token)
-
-    def clear_remember_token(self):
-        self.remember_token = None
-        self.remember_token_expiry = None
 
     def has_role(self, role_name):
         """Check if user has a specific role by name"""

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -79,34 +79,6 @@ class TestUserModel:
         assert user.reset_token is None
         assert user.reset_token_expiry is None
     
-    def test_user_remember_token(self, db_session):
-        """Test remember me token functionality"""
-        user = User(
-            name='Remember Test',
-            employee_number='REMEMBER001',
-            department='Testing'
-        )
-        user.set_password('test123')
-        db_session.add(user)
-        db_session.commit()
-        
-        # Generate remember token
-        token = user.generate_remember_token()
-        
-        assert token is not None
-        assert len(token) == 64  # 32 bytes hex = 64 chars
-        assert user.remember_token is not None
-        assert user.remember_token_expiry is not None
-        
-        # Verify token
-        assert user.check_remember_token(token)
-        assert not user.check_remember_token('invalid_token')
-        
-        # Clear token
-        user.clear_remember_token()
-        assert user.remember_token is None
-        assert user.remember_token_expiry is None
-    
     def test_user_account_lockout(self, db_session):
         """Test account lockout functionality"""
         user = User(

--- a/init_db.py
+++ b/init_db.py
@@ -24,9 +24,7 @@ CREATE TABLE IF NOT EXISTS users (
     is_active BOOLEAN DEFAULT 1,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     reset_token TEXT,
-    reset_token_expiry TIMESTAMP,
-    remember_token TEXT,
-    remember_token_expiry TIMESTAMP
+    reset_token_expiry TIMESTAMP
 )
 ''')
 


### PR DESCRIPTION
## Summary
- drop remember token attributes from models
- remove remember token code from tests
- adjust init_db table definition
- add migration script to remove remember token columns

## Testing
- `pip install -r backend/requirements.txt`
- `pip install requests`
- `PYTHONPATH=backend pytest -q` *(fails: ModuleNotFoundError and OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6858d553c1ec832c8719e2c3a9dbd33a