### PR TITLE
Switch backend routes to JWT auth

### DIFF
--- a/backend/routes_calibration.py
+++ b/backend/routes_calibration.py
@@ -1,34 +1,17 @@
-from flask import request, jsonify, session
+from flask import request, jsonify
 from models import db, Tool, User, ToolCalibration, CalibrationStandard, ToolCalibrationStandard, AuditLog, UserActivity
 from datetime import datetime, timedelta
-from functools import wraps
 import os
 import uuid
 from werkzeug.utils import secure_filename
 from utils.error_handler import handle_errors, ValidationError, log_security_event
 from utils.validation import validate_schema
-from utils.session_manager import SessionManager
+from auth import jwt_required, department_required
 import logging
 
 logger = logging.getLogger(__name__)
 
-# Decorator for requiring tool manager privileges
-def tool_manager_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        # Use secure session validation
-        valid, message = SessionManager.validate_session()
-        if not valid:
-            log_security_event('unauthorized_access_attempt', f'Tool management access denied: {message}')
-            return jsonify({'error': 'Authentication required', 'reason': message}), 401
-
-        # Check if user has admin or Materials department privileges
-        if not (session.get('is_admin', False) or session.get('department') == 'Materials'):
-            log_security_event('insufficient_permissions', f'Tool management access denied for user {session.get("user_id")}')
-            return jsonify({'error': 'Tool management privileges required'}), 403
-
-        return f(*args, **kwargs)
-    return decorated_function
+tool_manager_required = department_required('Materials')
 
 def register_calibration_routes(app):
     # Get all calibration records
@@ -215,7 +198,7 @@ def register_calibration_routes(app):
             tool_id=id,
             calibration_date=calibration_date,
             next_calibration_date=next_calibration_date,
-            performed_by_user_id=session['user_id'],
+            performed_by_user_id=request.current_user['user_id'],
             calibration_notes=validated_data.get('notes', ''),
             calibration_status=validated_data['calibration_status']
         )
@@ -247,13 +230,13 @@ def register_calibration_routes(app):
         # Create audit log
         log = AuditLog(
             action_type='tool_calibration',
-            action_details=f'User {session.get("name", "Unknown")} (ID: {session["user_id"]}) calibrated tool {tool.tool_number} (ID: {id})'
+            action_details=f'User {request.current_user.get("user_name", "Unknown")} (ID: {request.current_user["user_id"]}) calibrated tool {tool.tool_number} (ID: {id})'
         )
         db.session.add(log)
 
         # Create user activity
         activity = UserActivity(
-            user_id=session['user_id'],
+            user_id=request.current_user['user_id'],
             activity_type='tool_calibration',
             description=f'Calibrated tool {tool.tool_number}',
             ip_address=request.remote_addr
@@ -376,13 +359,13 @@ def register_calibration_routes(app):
             # Create audit log
             log = AuditLog(
                 action_type='add_calibration_standard',
-                action_details=f'User {session.get("name", "Unknown")} (ID: {session["user_id"]}) added calibration standard {standard.name} (ID: {standard.id})'
+                action_details=f'User {request.current_user.get("user_name", "Unknown")} (ID: {request.current_user["user_id"]}) added calibration standard {standard.name} (ID: {standard.id})'
             )
             db.session.add(log)
 
             # Create user activity
             activity = UserActivity(
-                user_id=session['user_id'],
+                user_id=request.current_user['user_id'],
                 activity_type='add_calibration_standard',
                 description=f'Added calibration standard {standard.name}',
                 ip_address=request.remote_addr
@@ -490,7 +473,7 @@ def register_calibration_routes(app):
             # Create audit log
             log = AuditLog(
                 action_type='update_calibration_standard',
-                action_details=f'User {session.get("name", "Unknown")} (ID: {session["user_id"]}) updated calibration standard {standard.name} (ID: {id})'
+                action_details=f'User {request.current_user.get("user_name", "Unknown")} (ID: {request.current_user["user_id"]}) updated calibration standard {standard.name} (ID: {id})'
             )
             db.session.add(log)
             db.session.commit()

--- a/backend/routes_chemical_analytics.py
+++ b/backend/routes_chemical_analytics.py
@@ -1,7 +1,7 @@
-from flask import request, jsonify, session
+from flask import request, jsonify
 from models import db, Chemical, ChemicalIssuance, User, AuditLog, UserActivity
 from datetime import datetime, timedelta
-from functools import wraps
+from auth import department_required
 import traceback
 from sqlalchemy import func
 
@@ -207,19 +207,7 @@ def calculate_shelf_life_stats(chemicals):
     return results
 
 # Decorator to check if user is admin or in Materials department
-def materials_manager_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        # Authentication check
-        if 'user_id' not in session:
-            return jsonify({'error': 'Authentication required'}), 401
-
-        # Check if user is admin or Materials department
-        if not (session.get('is_admin', False) or session.get('department') == 'Materials'):
-            return jsonify({'error': 'Materials management privileges required'}), 403
-
-        return f(*args, **kwargs)
-    return decorated_function
+materials_manager_required = department_required('Materials')
 
 def register_chemical_analytics_routes(app):
     # Get waste analytics

--- a/backend/routes_chemicals.py
+++ b/backend/routes_chemicals.py
@@ -1,32 +1,17 @@
-from flask import request, jsonify, session
+from flask import request, jsonify
 from models import db, Chemical, ChemicalIssuance, User, AuditLog, UserActivity
 from datetime import datetime, timedelta
 from functools import wraps
 from utils.error_handler import handle_errors, ValidationError, log_security_event, validate_input
 from utils.validation import validate_schema, validate_types, validate_constraints
-from utils.session_manager import SessionManager, secure_login_required
+from auth import jwt_required, department_required
 from sqlalchemy.orm import joinedload
 import logging
 
 logger = logging.getLogger(__name__)
 
 # Decorator to check if user is admin or in Materials department
-def materials_manager_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        # Use secure session validation
-        valid, message = SessionManager.validate_session()
-        if not valid:
-            log_security_event('unauthorized_access_attempt', f'Materials access denied: {message}')
-            return jsonify({'error': 'Authentication required', 'reason': message}), 401
-
-        # Check if user is admin or Materials department
-        if not (session.get('is_admin', False) or session.get('department') == 'Materials'):
-            log_security_event('insufficient_permissions', f'Materials access denied for user {session.get("user_id")}')
-            return jsonify({'error': 'Materials management privileges required'}), 403
-
-        return f(*args, **kwargs)
-    return decorated_function
+materials_manager_required = department_required('Materials')
 
 def register_chemical_routes(app):
     # Get all chemicals
@@ -189,9 +174,9 @@ def register_chemical_routes(app):
         db.session.add(log)
 
         # Log user activity
-        if 'user_id' in session:
+        if hasattr(request, 'current_user'):
             activity = UserActivity(
-                user_id=session['user_id'],
+                user_id=request.current_user['user_id'],
                 activity_type='chemical_added',
                 description=f"Added chemical {validated_data['part_number']} - {validated_data['lot_number']}"
             )
@@ -230,7 +215,7 @@ def register_chemical_routes(app):
 
     # Issue a chemical
     @app.route('/api/chemicals/<int:id>/issue', methods=['POST'])
-    @secure_login_required
+    @jwt_required
     @handle_errors
     def chemical_issue_route(id):
         # Get the chemical
@@ -289,9 +274,9 @@ def register_chemical_routes(app):
         db.session.add(log)
 
         # Log user activity
-        if 'user_id' in session:
+        if hasattr(request, 'current_user'):
             activity = UserActivity(
-                user_id=session['user_id'],
+                user_id=request.current_user['user_id'],
                 activity_type='chemical_issued',
                 description=f"Issued {quantity} {chemical.unit} of chemical {chemical.part_number} - {chemical.lot_number}"
             )
@@ -365,7 +350,7 @@ def register_chemical_routes(app):
                 return jsonify({'error': 'Failed to update reorder status'}), 500
 
             # Log the action
-            user_name = session.get('user_name', 'Unknown user')
+            user_name = request.current_user.get('user_name', 'Unknown user')
             log = AuditLog(
                 action_type='chemical_ordered',
                 action_details=f"Chemical {chemical.part_number} - {chemical.lot_number} marked as ordered by {user_name}"
@@ -373,9 +358,9 @@ def register_chemical_routes(app):
             db.session.add(log)
 
             # Log user activity
-            if 'user_id' in session:
+            if hasattr(request, 'current_user'):
                 activity = UserActivity(
-                    user_id=session['user_id'],
+                    user_id=request.current_user['user_id'],
                     activity_type='chemical_ordered',
                     description=f"Marked chemical {chemical.part_number} - {chemical.lot_number} as ordered"
                 )
@@ -478,7 +463,7 @@ def register_chemical_routes(app):
                 return jsonify({'error': 'Failed to update archive status'}), 500
 
             # Log the action
-            user_name = session.get('user_name', 'Unknown user')
+            user_name = request.current_user.get('user_name', 'Unknown user')
             log = AuditLog(
                 action_type='chemical_archived',
                 action_details=f"Chemical {chemical.part_number} - {chemical.lot_number} archived by {user_name}: {data.get('reason')}"
@@ -486,9 +471,9 @@ def register_chemical_routes(app):
             db.session.add(log)
 
             # Log user activity
-            if 'user_id' in session:
+            if hasattr(request, 'current_user'):
                 activity = UserActivity(
-                    user_id=session['user_id'],
+                    user_id=request.current_user['user_id'],
                     activity_type='chemical_archived',
                     description=f"Archived chemical {chemical.part_number} - {chemical.lot_number}: {data.get('reason')}"
                 )
@@ -531,7 +516,7 @@ def register_chemical_routes(app):
                 return jsonify({'error': 'Failed to update archive status'}), 500
 
             # Log the action
-            user_name = session.get('user_name', 'Unknown user')
+            user_name = request.current_user.get('user_name', 'Unknown user')
             log = AuditLog(
                 action_type='chemical_unarchived',
                 action_details=f"Chemical {chemical.part_number} - {chemical.lot_number} unarchived by {user_name}"
@@ -539,9 +524,9 @@ def register_chemical_routes(app):
             db.session.add(log)
 
             # Log user activity
-            if 'user_id' in session:
+            if hasattr(request, 'current_user'):
                 activity = UserActivity(
-                    user_id=session['user_id'],
+                    user_id=request.current_user['user_id'],
                     activity_type='chemical_unarchived',
                     description=f"Unarchived chemical {chemical.part_number} - {chemical.lot_number}"
                 )
@@ -616,7 +601,7 @@ def register_chemical_routes(app):
                 return jsonify({'error': 'Failed to update chemical status'}), 500
 
             # Log the action
-            user_name = session.get('user_name', 'Unknown user')
+            user_name = request.current_user.get('user_name', 'Unknown user')
             log = AuditLog(
                 action_type='chemical_delivered',
                 action_details=f"Chemical {chemical.part_number} - {chemical.lot_number} marked as delivered by {user_name}{quantity_log}"
@@ -624,9 +609,9 @@ def register_chemical_routes(app):
             db.session.add(log)
 
             # Log user activity
-            if 'user_id' in session:
+            if hasattr(request, 'current_user'):
                 activity = UserActivity(
-                    user_id=session['user_id'],
+                    user_id=request.current_user['user_id'],
                     activity_type='chemical_delivered',
                     description=f"Marked chemical {chemical.part_number} - {chemical.lot_number} as delivered{quantity_log}"
                 )

--- a/backend/routes_reports.py
+++ b/backend/routes_reports.py
@@ -1,4 +1,4 @@
-from flask import request, jsonify, session, make_response
+from flask import request, jsonify, make_response
 from datetime import datetime, timedelta
 from models import db, Tool, User, Checkout
 from models_cycle_count import (
@@ -24,20 +24,9 @@ def calculate_date_range(timeframe):
     else:
         return now - timedelta(days=30)  # Default to month
 from sqlalchemy import func, extract
-from functools import wraps
+from auth import department_required
 
-def tool_manager_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        if 'user_id' not in session:
-            return jsonify({'error': 'Authentication required'}), 401
-
-        # Allow access for admins or Materials department users
-        if session.get('is_admin', False) or session.get('department') == 'Materials':
-            return f(*args, **kwargs)
-
-        return jsonify({'error': 'Tool management privileges required'}), 403
-    return decorated_function
+tool_manager_required = department_required('Materials')
 
 def register_report_routes(app):
     # Export report as PDF


### PR DESCRIPTION
## Summary
- drop session-based auth in backend route modules
- use JWT decorators and `request.current_user`
- replace admin/materials checks with department/permission decorators

## Testing
- `python -m py_compile backend/routes_announcements.py backend/routes_calibration.py backend/routes_cycle_count.py backend/routes_reports.py backend/routes_chemical_analytics.py backend/routes_chemicals.py backend/routes_rbac.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6858d3630b74832ca2ff682bdcce9902