### PR TITLE
Refactor Playwright auth helpers

### DIFF
--- a/frontend/tests/e2e/utils/auth.js
+++ b/frontend/tests/e2e/utils/auth.js
@@ -19,28 +19,39 @@ export const TEST_USERS = {
 };
 
 /**
+ * Store auth tokens in localStorage
+ * @param {import('@playwright/test').Page} page
+ * @param {string} accessToken
+ * @param {string} refreshToken
+ */
+export async function setAuthTokens(page, accessToken, refreshToken) {
+  await page.evaluate(([a, r]) => {
+    localStorage.setItem('access_token', a);
+    localStorage.setItem('refresh_token', r);
+  }, [accessToken, refreshToken]);
+}
+
+/**
  * Login with specified user credentials
  * @param {import('@playwright/test').Page} page 
  * @param {Object} user - User credentials object
- * @param {boolean} rememberMe - Whether to check remember me option
  */
-export async function login(page, user = TEST_USERS.admin, rememberMe = false) {
-  await page.goto('/login');
-  
-  // Fill in credentials
-  await page.fill('input[placeholder="Enter employee number"]', user.username);
-  await page.fill('input[placeholder="Password"]', user.password);
-  
-  // Check remember me if requested
-  if (rememberMe) {
-    await page.check('input[type="checkbox"]');
+export async function login(page, user = TEST_USERS.admin) {
+  const response = await page.request.post('/api/auth/login', {
+    data: {
+      employee_number: user.username,
+      password: user.password
+    }
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Login failed: ${response.status()}`);
   }
-  
-  // Submit form
-  await page.click('button[type="submit"]');
-  
-  // Wait for redirect to dashboard
-  await page.waitForURL('/dashboard');
+
+  const data = await response.json();
+  await setAuthTokens(page, data.access_token, data.refresh_token);
+
+  await page.goto('/dashboard');
 }
 
 /**
@@ -48,14 +59,15 @@ export async function login(page, user = TEST_USERS.admin, rememberMe = false) {
  * @param {import('@playwright/test').Page} page 
  */
 export async function logout(page) {
-  // Click user menu
-  await page.click('[data-testid="user-menu"]');
-  
-  // Click logout
-  await page.click('text=Logout');
-  
-  // Wait for redirect to login
-  await page.waitForURL('/login');
+  const token = await page.evaluate(() => localStorage.getItem('access_token'));
+
+  if (token) {
+    await page.request.post('/api/auth/logout', {
+      headers: { Authorization: `Bearer ${token}` }
+    }).catch(() => {});
+  }
+
+  await clearAuthState(page);
 }
 
 /**


### PR DESCRIPTION
## Summary
- rewrite login() to use the `/api/auth/login` endpoint
- store returned JWT tokens in `localStorage`
- add `setAuthTokens` helper for programmatic token setup
- update logout() and authentication setup

## Testing
- `npx eslint tests/e2e/utils/auth.js` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: no output due to restricted network)*

------
https://chatgpt.com/codex/tasks/task_e_6858d6dfa41c832c81162ac0b740cf38