### PR TITLE
Update E2E auth util and tests

### DIFF
--- a/frontend/tests/e2e/auth.spec.js
+++ b/frontend/tests/e2e/auth.spec.js
@@ -22,7 +22,6 @@ test.describe('Authentication', () => {
     await expect(page.locator('input[placeholder="Enter employee number"]')).toBeVisible();
     await expect(page.locator('input[placeholder="Password"]')).toBeVisible();
     await expect(page.locator('button[type="submit"]')).toBeVisible();
-    await expect(page.locator('input[type="checkbox"]')).toBeVisible(); // Remember me checkbox
   });
 
   test('should show validation errors for empty fields', async ({ page }) => {
@@ -61,20 +60,6 @@ test.describe('Authentication', () => {
     await expect(page.locator('h1')).toContainText('Dashboard');
   });
 
-  test('should login with remember me option', async ({ page }) => {
-    // Fill in valid credentials
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    
-    // Check remember me
-    await page.check('input[type="checkbox"]');
-    
-    // Submit form
-    await page.click('button[type="submit"]');
-    
-    // Should redirect to dashboard (root path)
-    await expect(page).toHaveURL('/');
-  });
 
   test('should logout successfully', async ({ page }) => {
     // First login

--- a/frontend/tests/e2e/dashboard.spec.js
+++ b/frontend/tests/e2e/dashboard.spec.js
@@ -1,21 +1,9 @@
 import { test, expect } from '@playwright/test';
-
-// Test data
-const TEST_USER = {
-  username: 'ADMIN001',
-  password: 'admin123'
-};
+import { login, TEST_USERS } from './utils/auth.js';
 
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
-    // Login before each test
-    await page.goto('/login');
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    await page.click('button[type="submit"]');
-    
-    // Wait for dashboard to load
-    await expect(page).toHaveURL('/dashboard');
+    await login(page, TEST_USERS.admin);
   });
 
   test('should display dashboard title and main sections', async ({ page }) => {

--- a/frontend/tests/e2e/debug.spec.js
+++ b/frontend/tests/e2e/debug.spec.js
@@ -1,17 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { login, TEST_USERS } from './utils/auth.js';
 
 test.describe('Debug Tests', () => {
   test('debug page content after login', async ({ page }) => {
-    // Navigate to login page
-    await page.goto('/login');
-    
-    // Login
-    await page.fill('input[placeholder="Employee Number"]', 'USER001');
-    await page.fill('input[placeholder="Password"]', 'user123');
-    await page.click('button[type="submit"]');
-    
-    // Wait for redirect
-    await expect(page).toHaveURL('/');
+    await login(page, TEST_USERS.user);
     
     // Wait a moment for the page to fully load
     await page.waitForTimeout(2000);

--- a/frontend/tests/e2e/navigation.spec.js
+++ b/frontend/tests/e2e/navigation.spec.js
@@ -1,21 +1,9 @@
 import { test, expect } from '@playwright/test';
-
-// Test data
-const TEST_USER = {
-  username: 'ADMIN001',
-  password: 'admin123'
-};
+import { login, TEST_USERS } from './utils/auth.js';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {
-    // Login before each test
-    await page.goto('/login');
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    await page.click('button[type="submit"]');
-    
-    // Wait for dashboard to load
-    await expect(page).toHaveURL('/dashboard');
+    await login(page, TEST_USERS.admin);
   });
 
   test('should display main navigation menu', async ({ page }) => {

--- a/frontend/tests/e2e/security.spec.js
+++ b/frontend/tests/e2e/security.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { login, TEST_USERS } from './utils/auth.js';
 
 test.describe('Frontend Security Tests', () => {
   test.beforeEach(async ({ page }) => {
@@ -34,14 +35,8 @@ test.describe('Frontend Security Tests', () => {
   });
 
   test('should handle authentication token securely', async ({ page }) => {
-    // Navigate to login page
-    await page.goto('/login');
-    
-    // Login with valid credentials
-    await page.fill('input[placeholder="Employee Number"]', 'USER001');
-    await page.fill('input[placeholder="Password"]', 'user123');
-    await page.click('button[type="submit"]');
-    
+    await login(page, TEST_USERS.user);
+
     // Wait for potential redirect
     await page.waitForTimeout(3000);
     
@@ -158,11 +153,8 @@ test.describe('Frontend Security Tests', () => {
     // Should be redirected to login page
     await expect(page).toHaveURL('/login');
     
-    // Login with valid credentials
-    await page.fill('input[placeholder="Employee Number"]', 'USER001');
-    await page.fill('input[placeholder="Password"]', 'user123');
-    await page.click('button[type="submit"]');
-    
+    await login(page, TEST_USERS.user);
+
     // Wait for redirect to dashboard
     await page.waitForTimeout(3000);
     


### PR DESCRIPTION
## Summary
- programmatically authenticate E2E tests via JWT API
- drop "remember me" checks from authentication tests
- use token based login helper in dashboard, navigation, debug and security specs

## Testing
- `npx playwright test --list` *(fails: Cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6858d54ffd80832cbc013c4df8e0b566