### PR TITLE
Implement auth interceptor

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,17 +6,31 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // Important for cookies/session
 });
 
-// Request interceptor for adding auth token
+// Request interceptor for adding auth token and CSRF token
 api.interceptors.request.use(
   (config) => {
-    // You could add auth token here if using JWT
+    const accessToken = localStorage.getItem('access_token');
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    // Attach CSRF token for state-changing requests
+    const method = config.method ? config.method.toUpperCase() : 'GET';
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+      const csrfToken = localStorage.getItem('csrf_token');
+      if (csrfToken) {
+        config.headers['X-CSRF-Token'] = csrfToken;
+      }
+    }
+
     // Only log non-GET requests in development environment or when debugging is enabled
-    if (config.method.toUpperCase() !== 'GET' &&
-        (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')) {
-      console.log(`API Request [${config.method.toUpperCase()}] ${config.url}:`, config.data);
+    if (
+      method !== 'GET' &&
+      (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true')
+    ) {
+      console.log(`API Request [${method}] ${config.url}:`, config.data);
     }
     return config;
   },
@@ -30,21 +44,67 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   (response) => {
     // Only log responses in development environment or when debugging is enabled
-    if (process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG_MODE === 'true') {
-      console.log(`API Response [${response.config.method.toUpperCase()}] ${response.config.url}:`, response.data);
+    if (
+      process.env.NODE_ENV === 'development' ||
+      process.env.REACT_APP_DEBUG_MODE === 'true'
+    ) {
+      console.log(
+        `API Response [${response.config.method.toUpperCase()}] ${response.config.url}:`,
+        response.data
+      );
     }
 
     return response;
   },
-  (error) => {
-    // Handle common errors
-    console.error(`API Error [${error.config?.method?.toUpperCase()}] ${error.config?.url}:`, error.response?.data || error.message);
+  async (error) => {
+    const originalRequest = error.config;
 
-    if (error.response) {
-      // Server responded with error status
-      if (error.response.status === 401) {
-        // Unauthorized - redirect to login
+    // Handle common errors
+    console.error(
+      `API Error [${originalRequest?.method?.toUpperCase()}] ${originalRequest?.url}:`,
+      error.response?.data || error.message
+    );
+
+    if (error.response && error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = localStorage.getItem('refresh_token');
+        if (refreshToken) {
+          const refreshResponse = await api.post('/auth/refresh', { refresh_token: refreshToken });
+          const { access_token, refresh_token } = refreshResponse.data;
+          if (access_token) {
+            localStorage.setItem('access_token', access_token);
+          }
+          if (refresh_token) {
+            localStorage.setItem('refresh_token', refresh_token);
+          }
+
+          // Get new CSRF token
+          try {
+            const csrfRes = await api.get('/auth/csrf-token');
+            if (csrfRes.data?.csrf_token) {
+              localStorage.setItem('csrf_token', csrfRes.data.csrf_token);
+            }
+          } catch (_) {
+            // ignore CSRF fetch errors
+          }
+
+          originalRequest.headers.Authorization = `Bearer ${access_token}`;
+          if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(originalRequest.method.toUpperCase())) {
+            const csrfToken = localStorage.getItem('csrf_token');
+            if (csrfToken) {
+              originalRequest.headers['X-CSRF-Token'] = csrfToken;
+            }
+          }
+
+          return api(originalRequest);
+        }
+      } catch (refreshError) {
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        localStorage.removeItem('csrf_token');
         window.location.href = '/login';
+        return Promise.reject(refreshError);
       }
     }
     return Promise.reject(error);

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -6,9 +6,24 @@ const AuthService = {
     try {
       const response = await api.post('/auth/login', {
         employee_number: username,
-        password
+        password,
       });
-      return response.data;
+      const { access_token, refresh_token, user } = response.data;
+      if (access_token) {
+        localStorage.setItem('access_token', access_token);
+      }
+      if (refresh_token) {
+        localStorage.setItem('refresh_token', refresh_token);
+      }
+      try {
+        const csrfRes = await api.get('/auth/csrf-token');
+        if (csrfRes.data?.csrf_token) {
+          localStorage.setItem('csrf_token', csrfRes.data.csrf_token);
+        }
+      } catch (_) {
+        // ignore CSRF fetch errors
+      }
+      return user;
     } catch (error) {
       throw error;
     }
@@ -28,6 +43,9 @@ const AuthService = {
   logout: async () => {
     try {
       const response = await api.post('/auth/logout');
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('refresh_token');
+      localStorage.removeItem('csrf_token');
       return response.data;
     } catch (error) {
       throw error;


### PR DESCRIPTION
## Summary
- remove axios `withCredentials`
- add interceptors to attach `Authorization` and `X-CSRF-Token`
- refresh JWT tokens on 401
- store tokens in `AuthService`

## Testing
- `python -m pytest backend/tests` *(fails: ImportError)*
- `npx playwright install --with-deps` *(blocked: required interactive input)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858d54c5294832c8d09af4d183997dd