### PR TITLE
Update auth e2e tests for token storage

### DIFF
--- a/frontend/tests/e2e/auth.spec.js
+++ b/frontend/tests/e2e/auth.spec.js
@@ -22,7 +22,6 @@ test.describe('Authentication', () => {
     await expect(page.locator('input[placeholder="Enter employee number"]')).toBeVisible();
     await expect(page.locator('input[placeholder="Password"]')).toBeVisible();
     await expect(page.locator('button[type="submit"]')).toBeVisible();
-    await expect(page.locator('input[type="checkbox"]')).toBeVisible(); // Remember me checkbox
   });
 
   test('should show validation errors for empty fields', async ({ page }) => {
@@ -56,25 +55,15 @@ test.describe('Authentication', () => {
     
     // Should redirect to dashboard (root path)
     await expect(page).toHaveURL('/');
-    
+
     // Should see user dashboard elements
     await expect(page.locator('h1')).toContainText('Dashboard');
+
+    // Verify auth token stored
+    const token = await page.evaluate(() => localStorage.getItem('supplyline_access_token'));
+    expect(token).not.toBeNull();
   });
 
-  test('should login with remember me option', async ({ page }) => {
-    // Fill in valid credentials
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    
-    // Check remember me
-    await page.check('input[type="checkbox"]');
-    
-    // Submit form
-    await page.click('button[type="submit"]');
-    
-    // Should redirect to dashboard (root path)
-    await expect(page).toHaveURL('/');
-  });
 
   test('should logout successfully', async ({ page }) => {
     // First login
@@ -93,24 +82,12 @@ test.describe('Authentication', () => {
     
     // Should redirect to login page
     await expect(page).toHaveURL('/login');
+
+    // Tokens should be cleared
+    const token = await page.evaluate(() => localStorage.getItem('supplyline_access_token'));
+    expect(token).toBeNull();
   });
 
-  test('should persist authentication on page refresh', async ({ page }) => {
-    // Login first
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    await page.click('button[type="submit"]');
-    
-    // Wait for dashboard (root path)
-    await expect(page).toHaveURL('/');
-    
-    // Refresh the page
-    await page.reload();
-    
-    // Should still be on dashboard (not redirected to login)
-    await expect(page).toHaveURL('/');
-    await expect(page.locator('h1')).toContainText('Dashboard');
-  });
 
   test('should redirect to login when accessing protected route without auth', async ({ page }) => {
     // Try to access protected route directly
@@ -123,16 +100,22 @@ test.describe('Authentication', () => {
   test('should redirect back to intended page after login', async ({ page }) => {
     // Try to access protected route directly
     await page.goto('/tools');
-    
+
     // Should redirect to login
     await expect(page).toHaveURL('/login');
-    
+
     // Login
-    await page.fill('input[placeholder="Enter employee number"]', TEST_USER.username);
-    await page.fill('input[placeholder="Password"]', TEST_USER.password);
-    await page.click('button[type="submit"]');
-    
+    const [request] = await Promise.all([
+      page.waitForRequest(req => req.url().includes('/api/tools') && req.method() === 'GET'),
+      page.fill('input[placeholder="Enter employee number"]', TEST_USER.username),
+      page.fill('input[placeholder="Password"]', TEST_USER.password),
+      page.click('button[type="submit"]'),
+    ]);
+
     // Should redirect back to tools page
     await expect(page).toHaveURL('/tools');
+
+    // Authorization header should be sent
+    expect(request.headers()['authorization']).toBeTruthy();
   });
 });

--- a/frontend/tests/e2e/utils/auth.js
+++ b/frontend/tests/e2e/utils/auth.js
@@ -20,27 +20,24 @@ export const TEST_USERS = {
 
 /**
  * Login with specified user credentials
- * @param {import('@playwright/test').Page} page 
+ * @param {import('@playwright/test').Page} page
  * @param {Object} user - User credentials object
- * @param {boolean} rememberMe - Whether to check remember me option
  */
-export async function login(page, user = TEST_USERS.admin, rememberMe = false) {
+export async function login(page, user = TEST_USERS.admin) {
   await page.goto('/login');
   
   // Fill in credentials
   await page.fill('input[placeholder="Enter employee number"]', user.username);
   await page.fill('input[placeholder="Password"]', user.password);
   
-  // Check remember me if requested
-  if (rememberMe) {
-    await page.check('input[type="checkbox"]');
-  }
-  
   // Submit form
   await page.click('button[type="submit"]');
-  
+
   // Wait for redirect to dashboard
   await page.waitForURL('/dashboard');
+
+  // Wait until auth token is stored
+  await page.waitForFunction(() => localStorage.getItem('supplyline_access_token'));
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor login helper to remove remember-me logic and wait for tokens
- trim auth spec to remove remember-me and persistence checks
- assert tokens are stored and Authorization header is sent

## Testing
- `npx playwright test frontend/tests/e2e/auth.spec.js --project=chromium --timeout=10000 --workers=1` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858d6e13f48832ca4cd524b9f5dd9f8