### PR TITLE
docs: log UI defects for tool and chemical creation

### DIFF
--- a/docs/issues/0001-add-tool-endpoint-403.md
+++ b/docs/issues/0001-add-tool-endpoint-403.md
@@ -1,0 +1,23 @@
+# Bug: Add Tool endpoint rejects JWT-authenticated admins (403 Forbidden)
+
+## Summary
+Submitting the **Add New Tool** form as an authenticated admin user fails with a 403 Forbidden response. The backend endpoint for creating tools only trusts Flask session flags (e.g., `session['is_admin']`) instead of the administrator claims embedded in the JWT that the React frontend uses.
+
+## Steps to Reproduce
+1. Sign in to the web app as an administrator (e.g., `ADMIN001`).
+2. Navigate to **Tools → Add New Tool**.
+3. Fill in all required fields with valid data.
+4. Submit the form.
+
+## Expected Result
+The tool should be created successfully and appear in the tool inventory list.
+
+## Actual Result
+The UI displays a red banner stating the tool creation failed, and the network response is HTTP 403 Forbidden because the backend rejects the request when the Flask session is missing the `is_admin` flag.
+
+## Impact
+Administrators cannot add new tools through the UI even though they are authenticated, blocking a core workflow without manual database intervention.
+
+## Notes
+* Screenshot: [Add Tool failure](browser:/invocations/noqxenji/artifacts/artifacts/tool_created_success.png)
+* Related observation: the existing tool list works if a tool is seeded directly in the database.

--- a/docs/issues/0002-chemical-unit-validation.md
+++ b/docs/issues/0002-chemical-unit-validation.md
@@ -1,0 +1,24 @@
+# Bug: Chemical creation rejects valid unit selections
+
+## Summary
+Creating a new chemical fails for several units. Selecting "Liter (l)" in the **Add New Chemical** form produces an HTTP 400 error. The UI submits the abbreviated unit value (`l`), but the backend validation schema only accepts the long-form string (`liter`).
+
+## Steps to Reproduce
+1. Sign in to the application as an administrator.
+2. Navigate to **Chemicals → Add New Chemical**.
+3. Fill in all required fields with valid data.
+4. Choose **Liter (l)** from the unit dropdown.
+5. Submit the form.
+
+## Expected Result
+The chemical should be created successfully using the unit selected in the UI.
+
+## Actual Result
+The request returns HTTP 400 with a validation error stating the unit must be one of the accepted values. The backend accepts `liter`, while the frontend sends `l`.
+
+## Impact
+Administrators cannot add chemicals that use affected units (e.g., liters), blocking inventory entry for those measurements.
+
+## Notes
+* Screenshot: [Chemical creation error](browser:/invocations/ksdyxyxk/artifacts/artifacts/chemical_create_result.png)
+* This mismatch likely affects additional units where the abbreviation differs from the long-form value the backend expects.


### PR DESCRIPTION
## Summary
- document the Add Tool 403 error due to Flask session admin checks rejecting JWT-authenticated admins
- capture the chemical creation unit validation mismatch between frontend abbreviations and backend expectations

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc7ebe7b1c832cbe9a5c085bfdf0bc