### PR TITLE
Add password history tracking and enforce password expiry

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -32,6 +32,11 @@ def create_app():
     )
     app.config.from_object(Config)
 
+    # Ensure session storage is configured with a supported backend
+    session_type = app.config.get('SESSION_TYPE')
+    if not session_type or session_type.lower() == 'null':
+        app.config['SESSION_TYPE'] = 'filesystem'
+
     # Allow runtime overrides of the database URL (useful for tests)
     runtime_db_url = os.environ.get('DATABASE_URL')
     if runtime_db_url:

--- a/backend/migrations/add_password_history_tracking.py
+++ b/backend/migrations/add_password_history_tracking.py
@@ -1,0 +1,119 @@
+"""Migration script to add password history tracking infrastructure."""
+
+import logging
+import os
+import sys
+from datetime import datetime
+
+from flask import Flask
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table, inspect
+from sqlalchemy.exc import SQLAlchemyError
+
+from config import config
+from models import PasswordHistory, User, db
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def ensure_users_columns(inspector):
+    """Ensure password tracking columns exist on the users table."""
+    columns = {column['name'] for column in inspector.get_columns('users')}
+    dialect = db.engine.dialect.name
+
+    if 'force_password_change' not in columns:
+        logger.info("Adding force_password_change column to users table")
+        default_value = '0' if dialect == 'sqlite' else 'FALSE'
+        db.engine.execute(
+            f"ALTER TABLE users ADD COLUMN force_password_change BOOLEAN DEFAULT {default_value}"
+        )
+
+    if 'password_changed_at' not in columns:
+        logger.info("Adding password_changed_at column to users table")
+        column_type = 'DATETIME' if dialect == 'sqlite' else 'TIMESTAMP'
+        db.engine.execute(
+            f"ALTER TABLE users ADD COLUMN password_changed_at {column_type}"
+        )
+        db.engine.execute(
+            "UPDATE users SET password_changed_at = CURRENT_TIMESTAMP WHERE password_changed_at IS NULL"
+        )
+
+
+def ensure_password_history_table(inspector):
+    """Create password_history table if it does not exist."""
+    if 'password_history' in inspector.get_table_names():
+        return
+
+    logger.info("Creating password_history table")
+    metadata = MetaData()
+    metadata.bind = db.engine
+
+    password_history_table = Table(
+        'password_history',
+        metadata,
+        Column('id', Integer, primary_key=True),
+        Column('user_id', Integer, ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True),
+        Column('password_hash', String, nullable=False),
+        Column('created_at', DateTime, nullable=False, default=datetime.utcnow),
+    )
+
+    password_history_table.create(checkfirst=True)
+
+
+def backfill_password_history():
+    """Backfill password history entries for existing users."""
+    users = User.query.all()
+    inserted = 0
+    for user in users:
+        has_history = PasswordHistory.query.filter_by(user_id=user.id).first() is not None
+        if has_history:
+            continue
+
+        password_changed_at = user.password_changed_at or user.created_at or datetime.utcnow()
+        history = PasswordHistory(
+            user_id=user.id,
+            password_hash=user.password_hash,
+            created_at=password_changed_at,
+        )
+        db.session.add(history)
+        inserted += 1
+
+    if inserted:
+        logger.info("Inserted %s password history records", inserted)
+        db.session.commit()
+    else:
+        logger.info("No password history records required for backfill")
+
+
+def run_migration():
+    """Run the password history migration."""
+    inspector = inspect(db.engine)
+    ensure_users_columns(inspector)
+    ensure_password_history_table(inspector)
+    backfill_password_history()
+
+
+def main():
+    try:
+        config_name = os.environ.get('FLASK_ENV', 'development')
+        app = Flask(__name__)
+        app.config.from_object(config[config_name])
+        db.init_app(app)
+
+        with app.app_context():
+            logger.info("Running password history migration with config: %s", config_name)
+            run_migration()
+            logger.info("Password history migration completed successfully")
+            return True
+
+    except SQLAlchemyError as exc:
+        logger.error("Database error during migration: %s", exc)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Unexpected error during migration: %s", exc)
+
+    return False
+
+
+if __name__ == '__main__':
+    sys.exit(0 if main() else 1)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1985,9 +1985,14 @@ def register_routes(app):
         if not is_valid:
             return jsonify({'error': 'Password does not meet security requirements', 'details': errors}), 400
 
+        if hasattr(user, 'is_password_reused') and user.is_password_reused(data['new_password']):
+            return jsonify({'error': 'New password cannot match any of your last 5 passwords'}), 400
+
         # Update password
         user.set_password(data['new_password'])
         user.clear_reset_token()
+        if hasattr(user, 'force_password_change'):
+            user.force_password_change = False
         db.session.commit()
 
         # Log the password reset
@@ -2115,8 +2120,13 @@ def register_routes(app):
         if not is_valid:
             return jsonify({'error': 'Password does not meet security requirements', 'details': errors}), 400
 
+        if hasattr(user, 'is_password_reused') and user.is_password_reused(data['new_password']):
+            return jsonify({'error': 'New password cannot match any of your last 5 passwords'}), 400
+
         # Update password
         user.set_password(data['new_password'])
+        if hasattr(user, 'force_password_change'):
+            user.force_password_change = False
         db.session.commit()
 
         # Log the password change
@@ -2129,7 +2139,7 @@ def register_routes(app):
         db.session.add(activity)
         db.session.commit()
 
-        return jsonify({'message': 'Password updated successfully'}), 200
+        return jsonify({'message': 'Password changed successfully'}), 200
 
     @app.route('/api/user/activity', methods=['GET'])
     @login_required

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,8 +31,10 @@ def app():
 
     original_db_url = os.environ.get('DATABASE_URL')
     original_flask_env = os.environ.get('FLASK_ENV')
+    original_session_type = os.environ.get('SESSION_TYPE')
     os.environ['DATABASE_URL'] = f'sqlite:///{db_path}'
     os.environ['FLASK_ENV'] = 'testing'
+    os.environ['SESSION_TYPE'] = 'filesystem'
 
     try:
         global create_app, db, User, Tool, Chemical, UserActivity, AuditLog, JWTManager
@@ -69,6 +71,7 @@ def app():
             'SECRET_KEY': 'test-secret-key',
             'JWT_SECRET_KEY': 'test-jwt-secret-key',
             'RATE_LIMITS': {},
+            'SESSION_TYPE': 'filesystem',
         })
 
         yield application
@@ -82,6 +85,11 @@ def app():
             os.environ['FLASK_ENV'] = original_flask_env
         else:
             os.environ.pop('FLASK_ENV', None)
+
+        if original_session_type is not None:
+            os.environ['SESSION_TYPE'] = original_session_type
+        else:
+            os.environ.pop('SESSION_TYPE', None)
 
         os.close(db_fd)
         os.unlink(db_path)


### PR DESCRIPTION
## Summary
- add password history tracking model support and store the timestamp for the last password change
- enforce 90-day password expiry and prevent reusing the last five passwords across reset and change flows
- provide a migration script and updated tests/fixtures covering the new password policy requirements

## Testing
- pytest backend/tests/test_models.py::TestUserModel::test_password_history_limits_reuse -q
- pytest backend/tests/test_models.py::TestUserModel::test_password_expiration_flag -q
- pytest backend/tests/test_auth_security.py::TestJWTSecurity::test_password_expiry_requires_change -q
- pytest backend/tests/test_auth_security.py::TestJWTSecurity::test_password_reuse_blocked_on_change -q

------
https://chatgpt.com/codex/tasks/task_e_68eac65ad0f0832c9c9919b4fe8e4523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Prevent reusing any of the last 5 passwords during change or reset.
  - Enforce password expiration: expired passwords require an update on login.
  - Track password change timestamp; forced password change is honored when required.

- Style
  - Success copy updated to “Password changed successfully.”

- Chores
  - Improved default session backend handling for more reliable sessions.

- Tests
  - Added coverage for password expiration flow and password reuse prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->