### PR TITLE
Optimize password history pruning and tool inventory query

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -149,14 +149,15 @@ class User(db.Model):
         session.add(history_entry)
 
         # Maintain only the most recent 5 password history records
-        history_records = (
+        stale_history_records = (
             session.query(PasswordHistory)
             .filter_by(user_id=self.id)
             .order_by(PasswordHistory.created_at.desc(), PasswordHistory.id.desc())
+            .offset(5)
             .all()
         )
 
-        for stale_record in history_records[5:]:
+        for stale_record in stale_history_records:
             session.delete(stale_record)
 
     def check_password(self, password):


### PR DESCRIPTION
## Summary
- prune password history records with an offset query to avoid loading the entire history into memory
- update the tool inventory report to use correlated checkout filters and minimize repeated active checkout queries

## Testing
- pytest backend/test_performance_fixes.py

------
https://chatgpt.com/codex/tasks/task_e_68ee79831178832c903b09db32b10158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate tool availability and checked-out statuses in reports.
  * Clearer, context-specific error messages during report generation.

* **Performance**
  * Faster report generation through consolidated database queries, improving responsiveness for large tool lists.

* **API Changes**
  * Status is now computed per tool in responses; status_reason is included only when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->