### PR TITLE
Add security scan workflow for Bandit and npm audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,57 @@
+name: Security Scans
+
+on:
+  pull_request:
+    branches: [ master, main ]
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    name: Bandit Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'backend/requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+          if [ -f backend/requirements.txt ]; then
+            pip install -r backend/requirements.txt
+          fi
+
+      - name: Run Bandit
+        run: |
+          bandit -r backend -ll
+
+  npm-audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: frontend
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- add a pull-request security workflow that runs Bandit against the backend
- execute npm audit with an elevated threshold to catch high-severity issues in the frontend dependencies

## Testing
- bandit -r backend -ll
- npm audit --audit-level=high

------
https://chatgpt.com/codex/tasks/task_e_68fd28c58e34832caf27dd886cbd92bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated static analysis and dependency audit workflows that execute on pull requests targeting main branches, scanning both backend and frontend code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->