### PR TITLE
Add chemical return workflow

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -256,14 +256,12 @@ def sample_chemical(db_session, admin_user, test_warehouse):
         lot_number="L001",
         description="Test Chemical",
         manufacturer="Test Manufacturer",
-        quantity=100.0,
+        quantity=100,
         unit="ml",
         location="Test Location",
         category="Testing",
         status="available",
         warehouse_id=test_warehouse.id,
-        created_by=admin_user.id,
-        created_at=datetime.utcnow()
     )
     db_session.add(chemical)
     db_session.commit()

--- a/backend/utils/transaction_helper.py
+++ b/backend/utils/transaction_helper.py
@@ -162,6 +162,24 @@ def record_chemical_issuance(chemical_id, user_id, quantity, hangar=None, purpos
     )
 
 
+def record_chemical_return(chemical_id, user_id, quantity, location_from=None, location_to=None, notes=None):
+    """Record a chemical return transaction."""
+    chemical = Chemical.query.get(chemical_id)
+    if not chemical:
+        raise ValueError(f"Chemical {chemical_id} not found")
+
+    return record_transaction(
+        item_type="chemical",
+        item_id=chemical_id,
+        transaction_type="return",
+        user_id=user_id,
+        quantity_change=quantity,
+        location_from=location_from,
+        location_to=location_to or chemical.location,
+        notes=notes,
+    )
+
+
 def record_kit_item_transfer(item_type, item_id, user_id, from_location, to_location, quantity=None, reference=None, notes=None):
     """Record a kit item transfer transaction"""
     return record_transaction(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,6 +72,7 @@ import ChemicalDetailPage from './pages/ChemicalDetailPage';
 import NewChemicalPage from './pages/NewChemicalPage';
 import EditChemicalPage from './pages/EditChemicalPage';
 import ChemicalIssuePage from './pages/ChemicalIssuePage';
+import ChemicalReturnPage from './pages/ChemicalReturnPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
 import CalibrationManagement from './pages/CalibrationManagement';
 import ToolCalibrationForm from './pages/ToolCalibrationForm';
@@ -285,6 +286,22 @@ function App() {
           <PermissionRoute permission="page.chemicals">
             <MainLayout>
               <ChemicalIssuePage />
+            </MainLayout>
+          </PermissionRoute>
+        } />
+
+        <Route path="/chemicals/:id/return" element={
+          <PermissionRoute permission="page.chemicals">
+            <MainLayout>
+              <ChemicalReturnPage />
+            </MainLayout>
+          </PermissionRoute>
+        } />
+
+        <Route path="/chemicals/return" element={
+          <PermissionRoute permission="page.chemicals">
+            <MainLayout>
+              <ChemicalReturnPage />
             </MainLayout>
           </PermissionRoute>
         } />

--- a/frontend/src/components/chemicals/ChemicalIssuanceHistory.jsx
+++ b/frontend/src/components/chemicals/ChemicalIssuanceHistory.jsx
@@ -22,6 +22,8 @@ const ChemicalIssuanceHistory = ({ issuances, loading }) => {
                   <th>Date</th>
                   <th>Issued By</th>
                   <th>Quantity</th>
+                  <th>Returned</th>
+                  <th>Remaining</th>
                   <th>Hangar</th>
                   <th>Purpose</th>
                 </tr>
@@ -32,6 +34,8 @@ const ChemicalIssuanceHistory = ({ issuances, loading }) => {
                     <td>{new Date(issuance.issue_date).toLocaleString()}</td>
                     <td>{issuance.user_name}</td>
                     <td>{issuance.quantity}</td>
+                    <td>{issuance.total_returned ?? 0}</td>
+                    <td>{issuance.remaining_quantity ?? issuance.quantity}</td>
                     <td>{issuance.hangar}</td>
                     <td>{issuance.purpose || 'N/A'}</td>
                   </tr>

--- a/frontend/src/components/chemicals/ChemicalReturnHistory.jsx
+++ b/frontend/src/components/chemicals/ChemicalReturnHistory.jsx
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import { Card, Table, Alert } from 'react-bootstrap';
+import LoadingSpinner from '../common/LoadingSpinner';
+
+const ChemicalReturnHistory = ({ returns = [], loading }) => {
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header className="bg-light">
+        <h4 className="mb-0">Return History</h4>
+      </Card.Header>
+      <Card.Body>
+        {returns.length === 0 ? (
+          <Alert variant="info">No returns have been recorded for this chemical.</Alert>
+        ) : (
+          <div className="table-responsive">
+            <Table hover bordered className="align-middle">
+              <thead className="bg-light">
+                <tr>
+                  <th>Date</th>
+                  <th>Returned By</th>
+                  <th>Quantity</th>
+                  <th>Warehouse</th>
+                  <th>Location</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {returns.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.return_date ? new Date(entry.return_date).toLocaleString() : '—'}</td>
+                    <td>{entry.returned_by_name || 'Unknown'}</td>
+                    <td>{entry.quantity}</td>
+                    <td>{entry.warehouse_name || 'N/A'}</td>
+                    <td>{entry.location || 'N/A'}</td>
+                    <td>{entry.notes || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
+ChemicalReturnHistory.propTypes = {
+  returns: PropTypes.array,
+  loading: PropTypes.bool,
+};
+
+export default ChemicalReturnHistory;

--- a/frontend/src/pages/ChemicalDetailPage.jsx
+++ b/frontend/src/pages/ChemicalDetailPage.jsx
@@ -2,9 +2,15 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Card, Row, Col, Badge, Alert, Tab, Tabs, Form, Modal } from 'react-bootstrap';
-import { fetchChemicalById, fetchChemicalIssuances, archiveChemical } from '../store/chemicalsSlice';
+import {
+  fetchChemicalById,
+  fetchChemicalIssuances,
+  fetchChemicalReturns,
+  archiveChemical,
+} from '../store/chemicalsSlice';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import ChemicalIssuanceHistory from '../components/chemicals/ChemicalIssuanceHistory';
+import ChemicalReturnHistory from '../components/chemicals/ChemicalReturnHistory';
 import ChemicalBarcode from '../components/chemicals/ChemicalBarcode';
 import ConfirmModal from '../components/common/ConfirmModal';
 
@@ -12,7 +18,15 @@ const ChemicalDetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { currentChemical, loading, error, issuances, issuanceLoading } = useSelector((state) => state.chemicals);
+  const {
+    currentChemical,
+    loading,
+    error,
+    issuances,
+    issuanceLoading,
+    returns,
+    returnsLoading,
+  } = useSelector((state) => state.chemicals);
   const { user } = useSelector((state) => state.auth);
   const isAuthorized = user?.is_admin || user?.department === 'Materials';
 
@@ -26,6 +40,7 @@ const ChemicalDetailPage = () => {
     if (id) {
       dispatch(fetchChemicalById(id));
       dispatch(fetchChemicalIssuances(id));
+      dispatch(fetchChemicalReturns(id));
     }
   }, [dispatch, id]);
 
@@ -120,6 +135,12 @@ const ChemicalDetailPage = () => {
                 Issue Chemical
               </Button>
               <Button
+                variant="outline-success"
+                onClick={() => navigate(`/chemicals/${id}/return`)}
+              >
+                Return Chemical
+              </Button>
+              <Button
                 variant="info"
                 onClick={() => setShowBarcodeModal(true)}
               >
@@ -210,9 +231,14 @@ const ChemicalDetailPage = () => {
       <Tabs defaultActiveKey="issuances" className="mb-3">
         <Tab eventKey="issuances" title="Issuance History">
           <ChemicalIssuanceHistory
-            chemicalId={id}
             issuances={issuances[id] || []}
             loading={issuanceLoading}
+          />
+        </Tab>
+        <Tab eventKey="returns" title="Return History">
+          <ChemicalReturnHistory
+            returns={returns[id] || []}
+            loading={returnsLoading}
           />
         </Tab>
       </Tabs>

--- a/frontend/src/pages/ChemicalReturnPage.jsx
+++ b/frontend/src/pages/ChemicalReturnPage.jsx
@@ -1,0 +1,430 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Form,
+  InputGroup,
+  Row,
+  Spinner,
+} from 'react-bootstrap';
+import { FaBarcode, FaSearch, FaUndo } from 'react-icons/fa';
+import api from '../services/api';
+import {
+  fetchChemicalReturns,
+  lookupChemicalReturn,
+  submitChemicalReturn,
+} from '../store/chemicalsSlice';
+import LoadingSpinner from '../components/common/LoadingSpinner';
+import ChemicalBarcode from '../components/chemicals/ChemicalBarcode';
+import ChemicalReturnHistory from '../components/chemicals/ChemicalReturnHistory';
+
+const ChemicalReturnPage = () => {
+  const { id } = useParams();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const {
+    returnLookup,
+    returnLookupLoading,
+    returnLookupError,
+    returnSubmitting,
+    returnSubmitError,
+    lastReturn,
+    returns,
+    returnsLoading,
+  } = useSelector((state) => state.chemicals);
+  const { user } = useSelector((state) => state.auth);
+  const isAuthorized = user?.is_admin || user?.department === 'Materials';
+
+  const [barcodeValue, setBarcodeValue] = useState('');
+  const [warehouses, setWarehouses] = useState([]);
+  const [warehousesLoading, setWarehousesLoading] = useState(false);
+  const [warehousesError, setWarehousesError] = useState(null);
+  const [formData, setFormData] = useState({
+    quantity: '',
+    warehouse_id: '',
+    location: '',
+    notes: '',
+  });
+  const [validated, setValidated] = useState(false);
+  const [showBarcodeModal, setShowBarcodeModal] = useState(false);
+
+  const chemicalId = returnLookup?.chemical?.id;
+  const remainingQuantity = returnLookup?.remaining_quantity ?? null;
+  const returnHistory = useMemo(
+    () => (chemicalId != null ? returns[String(chemicalId)] || [] : []),
+    [returns, chemicalId]
+  );
+
+  useEffect(() => {
+    const loadWarehouses = async () => {
+      setWarehousesLoading(true);
+      setWarehousesError(null);
+      try {
+        const response = await api.get('/warehouses');
+        setWarehouses(Array.isArray(response.data) ? response.data : response.data?.warehouses || []);
+      } catch (error) {
+        console.error('Failed to load warehouses', error);
+        setWarehousesError('Unable to load warehouses. Please try again.');
+      } finally {
+        setWarehousesLoading(false);
+      }
+    };
+
+    loadWarehouses();
+  }, []);
+
+  useEffect(() => {
+    if (id) {
+      dispatch(lookupChemicalReturn({ chemical_id: parseInt(id, 10) }));
+    }
+  }, [dispatch, id]);
+
+  useEffect(() => {
+    if (returnLookup?.chemical?.id) {
+      setFormData((prev) => ({
+        ...prev,
+        quantity: returnLookup.remaining_quantity ?? '',
+        warehouse_id: returnLookup.default_warehouse_id || '',
+        location: returnLookup.default_location || '',
+        notes: '',
+      }));
+      dispatch(fetchChemicalReturns(returnLookup.chemical.id));
+    }
+  }, [dispatch, returnLookup]);
+
+  useEffect(() => {
+    if (lastReturn && returnLookup?.chemical) {
+      setShowBarcodeModal(true);
+    }
+  }, [lastReturn, returnLookup]);
+
+  useEffect(() => {
+    if (!isAuthorized) {
+      navigate('/chemicals', { replace: true });
+    }
+  }, [isAuthorized, navigate]);
+
+  const handleLookup = (event) => {
+    event.preventDefault();
+    if (!barcodeValue.trim()) {
+      return;
+    }
+    dispatch(lookupChemicalReturn({ code: barcodeValue.trim() }));
+  };
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+
+    if (form.checkValidity() === false) {
+      setValidated(true);
+      return;
+    }
+
+    const quantity = parseInt(formData.quantity, 10);
+    if (Number.isNaN(quantity) || quantity <= 0) {
+      return;
+    }
+
+    if (remainingQuantity !== null && quantity > remainingQuantity) {
+      return;
+    }
+
+    if (!chemicalId) {
+      return;
+    }
+
+    const payload = {
+      issuance_id: returnLookup?.issuance?.id,
+      quantity,
+      warehouse_id: formData.warehouse_id ? parseInt(formData.warehouse_id, 10) : null,
+      location: formData.location,
+      notes: formData.notes,
+    };
+
+    dispatch(submitChemicalReturn({ chemicalId, data: payload })).then((action) => {
+      if (action.meta.requestStatus === 'fulfilled') {
+        setValidated(false);
+      }
+    });
+  };
+
+  if (!isAuthorized) {
+    return null;
+  }
+
+  return (
+    <div className="w-100">
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h1>Return Issued Chemical</h1>
+        <Button variant="secondary" onClick={() => navigate('/chemicals')}>
+          Back to Chemicals
+        </Button>
+      </div>
+
+      <Row className="g-4">
+        <Col lg={4}>
+          <Card className="shadow-sm h-100">
+            <Card.Header className="bg-light">
+              <h4 className="mb-0">
+                <FaBarcode className="me-2" /> Scan Issued Lot
+              </h4>
+            </Card.Header>
+            <Card.Body>
+              <Form onSubmit={handleLookup}>
+                <Form.Group className="mb-3">
+                  <Form.Label>Barcode or Lot Code</Form.Label>
+                  <InputGroup>
+                    <InputGroup.Text>
+                      <FaSearch />
+                    </InputGroup.Text>
+                    <Form.Control
+                      type="text"
+                      value={barcodeValue}
+                      placeholder="Scan or enter barcode"
+                      onChange={(event) => setBarcodeValue(event.target.value)}
+                      disabled={returnLookupLoading}
+                    />
+                  </InputGroup>
+                  <Form.Text className="text-muted">
+                    Use a scanner to populate this field automatically.
+                  </Form.Text>
+                </Form.Group>
+                <div className="d-flex justify-content-between">
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={returnLookupLoading || !barcodeValue.trim()}
+                  >
+                    {returnLookupLoading ? (
+                      <>
+                        <Spinner animation="border" size="sm" className="me-2" />
+                        Searching...
+                      </>
+                    ) : (
+                      <>
+                        <FaSearch className="me-2" />
+                        Lookup
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline-secondary"
+                    onClick={() => {
+                      setBarcodeValue('');
+                      setFormData({ quantity: '', warehouse_id: '', location: '', notes: '' });
+                      setValidated(false);
+                    }}
+                  >
+                    <FaUndo className="me-2" />
+                    Reset
+                  </Button>
+                </div>
+              </Form>
+
+              {returnLookupError && (
+                <Alert variant="danger" className="mt-3">
+                  {returnLookupError.message || 'Failed to locate issued lot'}
+                </Alert>
+              )}
+
+              {warehousesError && (
+                <Alert variant="warning" className="mt-3">
+                  {warehousesError}
+                </Alert>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+
+        <Col lg={8}>
+          {returnLookupLoading && !returnLookup ? (
+            <LoadingSpinner />
+          ) : returnLookup?.chemical ? (
+            <Card className="shadow-sm">
+              <Card.Header className="bg-light">
+                <div className="d-flex justify-content-between align-items-center">
+                  <h4 className="mb-0">
+                    {returnLookup.chemical.part_number} — {returnLookup.chemical.lot_number}
+                  </h4>
+                  <span className="text-muted">
+                    Issued Quantity: {returnLookup.issuance?.quantity || '—'}
+                  </span>
+                </div>
+              </Card.Header>
+              <Card.Body>
+                {remainingQuantity === 0 && (
+                  <Alert variant="info">
+                    All issued quantity for this lot has been returned.
+                  </Alert>
+                )}
+
+                {lastReturn && (
+                  <Alert variant="success">
+                    Return recorded successfully. A barcode label will open for printing.
+                  </Alert>
+                )}
+
+                {returnSubmitError && (
+                  <Alert variant="danger">{returnSubmitError.message || 'Failed to complete return'}.</Alert>
+                )}
+
+                <Row className="mb-4">
+                  <Col md={6}>
+                    <h5>Chemical Information</h5>
+                    <p className="mb-1">
+                      <strong>Description:</strong> {returnLookup.chemical.description || 'N/A'}
+                    </p>
+                    <p className="mb-1">
+                      <strong>Warehouse:</strong> {returnLookup.chemical.warehouse_name || 'N/A'}
+                    </p>
+                    <p className="mb-1">
+                      <strong>Location:</strong> {returnLookup.chemical.location || 'N/A'}
+                    </p>
+                  </Col>
+                  <Col md={6}>
+                    <h5>Issuance Summary</h5>
+                    <p className="mb-1">
+                      <strong>Issued By:</strong> {returnLookup.issuance?.user_name || 'Unknown'}
+                    </p>
+                    <p className="mb-1">
+                      <strong>Issued For:</strong> {returnLookup.issuance?.hangar || 'N/A'}
+                    </p>
+                    <p className="mb-1">
+                      <strong>Remaining to Return:</strong>{' '}
+                      {remainingQuantity ?? '—'}
+                    </p>
+                  </Col>
+                </Row>
+
+                <Form noValidate validated={validated} onSubmit={handleSubmit}>
+                  <Row className="g-3">
+                    <Col md={4}>
+                      <Form.Group controlId="returnQuantity">
+                        <Form.Label>Quantity to Return*</Form.Label>
+                        <Form.Control
+                          type="number"
+                          name="quantity"
+                          value={formData.quantity}
+                          min={1}
+                          max={remainingQuantity ?? undefined}
+                          disabled={returnSubmitting || remainingQuantity === 0}
+                          required
+                          onChange={handleFormChange}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                          Please enter a valid quantity.
+                        </Form.Control.Feedback>
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId="returnWarehouse">
+                        <Form.Label>Return Warehouse</Form.Label>
+                        <Form.Select
+                          name="warehouse_id"
+                          value={formData.warehouse_id}
+                          onChange={handleFormChange}
+                          disabled={returnSubmitting || warehousesLoading}
+                        >
+                          <option value="">Select warehouse...</option>
+                          {warehouses.map((warehouse) => (
+                            <option key={warehouse.id} value={warehouse.id}>
+                              {warehouse.name}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId="returnLocation">
+                        <Form.Label>Return Location</Form.Label>
+                        <Form.Control
+                          type="text"
+                          name="location"
+                          placeholder="Shelf, bay, etc."
+                          value={formData.location}
+                          onChange={handleFormChange}
+                          disabled={returnSubmitting}
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={12}>
+                      <Form.Group controlId="returnNotes">
+                        <Form.Label>Notes</Form.Label>
+                        <Form.Control
+                          as="textarea"
+                          rows={3}
+                          name="notes"
+                          value={formData.notes}
+                          onChange={handleFormChange}
+                          placeholder="Add any relevant details about this return"
+                          disabled={returnSubmitting}
+                        />
+                      </Form.Group>
+                    </Col>
+                  </Row>
+
+                  <div className="d-flex justify-content-end mt-4">
+                    <Button
+                      type="submit"
+                      variant="success"
+                      disabled={returnSubmitting || remainingQuantity === 0}
+                    >
+                      {returnSubmitting ? (
+                        <>
+                          <Spinner animation="border" size="sm" className="me-2" />
+                          Recording Return...
+                        </>
+                      ) : (
+                        <>
+                          <FaBarcode className="me-2" />
+                          Complete Return
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </Form>
+              </Card.Body>
+            </Card>
+          ) : (
+            <Card className="shadow-sm">
+              <Card.Body>
+                <Alert variant="info" className="mb-0">
+                  Scan an issued lot barcode to begin the return process.
+                </Alert>
+              </Card.Body>
+            </Card>
+          )}
+        </Col>
+      </Row>
+
+      {chemicalId && (
+        <div className="mt-4">
+          <ChemicalReturnHistory returns={returnHistory} loading={returnsLoading} />
+        </div>
+      )}
+
+      <ChemicalBarcode
+        show={showBarcodeModal}
+        onHide={() => setShowBarcodeModal(false)}
+        chemical={returnLookup?.chemical || null}
+      />
+    </div>
+  );
+};
+
+export default ChemicalReturnPage;

--- a/frontend/src/services/chemicalService.js
+++ b/frontend/src/services/chemicalService.js
@@ -90,6 +90,39 @@ const ChemicalService = {
     }
   },
 
+  // Lookup issued chemical for returns
+  lookupChemicalReturn: async (payload) => {
+    try {
+      const response = await api.post('/chemicals/returns/lookup', payload);
+      return response.data;
+    } catch (error) {
+      console.error('API Error [POST] /chemicals/returns/lookup:', error);
+      throw error;
+    }
+  },
+
+  // Submit a chemical return
+  returnChemical: async (id, data) => {
+    try {
+      const response = await api.post(`/chemicals/${id}/return`, data);
+      return response.data;
+    } catch (error) {
+      console.error(`API Error [POST] /chemicals/${id}/return:`, error);
+      throw error;
+    }
+  },
+
+  // Get chemical return history
+  getChemicalReturns: async (id) => {
+    try {
+      const response = await api.get(`/chemicals/${id}/returns`);
+      return response.data;
+    } catch (error) {
+      console.error(`API Error [GET] /chemicals/${id}/returns:`, error);
+      throw error;
+    }
+  },
+
   // Get all issuances
   getAllIssuances: async (filters = {}) => {
     try {


### PR DESCRIPTION
## Summary
- add a ChemicalReturn model and expose lookup/return endpoints for issued lots
- record chemical returns in history and transaction logs with regression tests
- create a chemical return page, store actions, and UI updates for scanning, returning, and printing labels

## Testing
- pytest tests/test_routes.py::TestChemicalRoutes -q

------
https://chatgpt.com/codex/tasks/task_e_690a30c777b4832c84639e33e48f8da7