### PR TITLE
Add dedicated mobile experience for logged-in users

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { HotkeyProvider } from './context/HotkeyContext';
 import MainLayout from './components/common/MainLayout';
 import GlobalHotkeys from './components/common/GlobalHotkeys';
 import ProtectedRoute, { AdminRoute, PermissionRoute } from './components/auth/ProtectedRoute';
+import MobileLayout from './components/mobile/MobileLayout';
 
 // Import pages
 import LandingPage from './pages/LandingPage';
@@ -29,6 +30,7 @@ import RegisterPage from './pages/RegisterPage';
 import ProfilePageNew from './pages/ProfilePageNew';
 import DirectoryPage from './pages/DirectoryPage';
 import UserDashboardPage from './pages/UserDashboardPage';
+import MobileHomePage from './pages/MobileHomePage';
 import ToolsManagement from './pages/ToolsManagement';
 import ToolDetailPage from './pages/ToolDetailPage';
 import NewToolPage from './pages/NewToolPage';
@@ -97,14 +99,15 @@ import AircraftTypeManagement from './components/admin/AircraftTypeManagement';
 import WarehousesManagement from './pages/WarehousesManagement';
 import ItemHistoryPage from './pages/ItemHistoryPage';
 import OrderManagementPage from './pages/OrderManagementPage';
+import useIsMobileDevice from './hooks/useIsMobileDevice';
 
 // Component to handle root route - show landing page for unauthenticated, dashboard for authenticated
-const RootRoute = () => {
+const RootRoute = ({ isMobileDevice }) => {
   const { isAuthenticated, user } = useSelector((state) => state.auth);
 
   // If authenticated and we have user data, redirect to dashboard
   if (isAuthenticated && user) {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to={isMobileDevice ? '/mobile' : '/dashboard'} replace />;
   }
 
   // Otherwise show landing page
@@ -114,6 +117,7 @@ const RootRoute = () => {
 function App() {
   const dispatch = useDispatch();
   const { theme } = useSelector((state) => state.theme);
+  const isMobileDevice = useIsMobileDevice();
 
   useEffect(() => {
     // Always try to fetch current user on app load to check for existing session
@@ -151,15 +155,30 @@ function App() {
             <Route path="/register" element={<RegisterPage />} />
 
             {/* Root route - Landing page for unauthenticated, Dashboard for authenticated */}
-            <Route path="/" element={<RootRoute />} />
+            <Route path="/" element={<RootRoute isMobileDevice={isMobileDevice} />} />
 
             <Route path="/dashboard" element={
               <ProtectedRoute>
-                <MainLayout>
-                  <UserDashboardPage />
-                </MainLayout>
+                {isMobileDevice ? (
+                  <Navigate to="/mobile" replace />
+                ) : (
+                  <MainLayout>
+                    <UserDashboardPage />
+                  </MainLayout>
+                )}
               </ProtectedRoute>
             } />
+
+            <Route
+              path="/mobile"
+              element={
+                <ProtectedRoute>
+                  <MobileLayout>
+                    <MobileHomePage />
+                  </MobileLayout>
+                </ProtectedRoute>
+              }
+            />
 
             <Route
               path="/directory"

--- a/frontend/src/components/mobile/MobileLayout.css
+++ b/frontend/src/components/mobile/MobileLayout.css
@@ -1,0 +1,109 @@
+.mobile-shell {
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 20%, rgba(0, 102, 255, 0.08), transparent 32%),
+    radial-gradient(circle at 90% 10%, rgba(0, 163, 255, 0.1), transparent 28%),
+    radial-gradient(circle at 50% 80%, rgba(0, 102, 255, 0.06), transparent 35%),
+    linear-gradient(180deg, #0f172a 0%, #0b1222 45%, #060b16 100%);
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 88px;
+}
+
+.mobile-shell__header {
+  padding: 1.5rem 1.25rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  position: sticky;
+  top: 0;
+  background: linear-gradient(180deg, rgba(8, 14, 26, 0.9) 0%, rgba(6, 11, 22, 0.7) 100%);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  z-index: 2;
+}
+
+.mobile-shell__eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  margin: 0 0 0.35rem;
+}
+
+.mobile-shell__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.mobile-shell__subtitle {
+  margin: 0.35rem 0 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.mobile-shell__content {
+  flex: 1;
+  padding: 0 1.25rem 1.5rem;
+}
+
+.mobile-shell__nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(10, 15, 28, 0.94);
+  backdrop-filter: blur(14px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+  padding: 0.5rem 0.35rem 0.75rem;
+  z-index: 3;
+}
+
+.mobile-shell__nav-item {
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.35rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.mobile-shell__nav-item.active {
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.12), rgba(0, 163, 255, 0.14));
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}
+
+.mobile-shell__nav-item:active {
+  transform: translateY(1px);
+}
+
+.mobile-shell__nav-icon {
+  font-size: 1.15rem;
+}
+
+.mobile-shell__nav-label {
+  font-size: 0.75rem;
+}
+
+@media (min-width: 992px) {
+  .mobile-shell {
+    max-width: 560px;
+    margin: 0 auto;
+    border-radius: 24px;
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+  }
+}

--- a/frontend/src/components/mobile/MobileLayout.jsx
+++ b/frontend/src/components/mobile/MobileLayout.jsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { FaHome, FaBarcode, FaTools, FaClipboardList, FaUser } from 'react-icons/fa';
+import './MobileLayout.css';
+
+const MobileLayout = ({ children }) => {
+  const { user } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const navItems = useMemo(
+    () => [
+      { label: 'Home', icon: <FaHome />, path: '/mobile' },
+      { label: 'Scan', icon: <FaBarcode />, path: '/scanner' },
+      { label: 'Tools', icon: <FaTools />, path: '/tools' },
+      { label: 'Requests', icon: <FaClipboardList />, path: '/requests' },
+      { label: 'Profile', icon: <FaUser />, path: '/profile' }
+    ],
+    []
+  );
+
+  const isActive = (path) => {
+    if (path === '/mobile') {
+      return location.pathname === '/mobile';
+    }
+    return location.pathname.startsWith(path);
+  };
+
+  return (
+    <div className="mobile-shell">
+      <header className="mobile-shell__header">
+        <div>
+          <p className="mobile-shell__eyebrow">Signed in as</p>
+          <h1 className="mobile-shell__title">{user?.full_name || user?.username || 'Team Member'}</h1>
+          <p className="mobile-shell__subtitle">Tap a shortcut below to jump into your next task.</p>
+        </div>
+      </header>
+
+      <main className="mobile-shell__content">{children}</main>
+
+      <nav className="mobile-shell__nav" aria-label="Mobile primary navigation">
+        {navItems.map((item) => (
+          <button
+            key={item.path}
+            type="button"
+            className={`mobile-shell__nav-item ${isActive(item.path) ? 'active' : ''}`}
+            onClick={() => navigate(item.path)}
+          >
+            <span className="mobile-shell__nav-icon" aria-hidden>{item.icon}</span>
+            <span className="mobile-shell__nav-label">{item.label}</span>
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+};
+
+export default MobileLayout;

--- a/frontend/src/hooks/useIsMobileDevice.js
+++ b/frontend/src/hooks/useIsMobileDevice.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+const isTouchUserAgent = () => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || navigator.vendor || window.opera || '';
+  return /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(ua);
+};
+
+const useIsMobileDevice = (breakpoint = 900) => {
+  const getIsMobile = () => {
+    if (typeof window === 'undefined') return false;
+    const widthMatch = window.matchMedia(`(max-width: ${breakpoint}px)`).matches;
+    return isTouchUserAgent() || widthMatch;
+  };
+
+  const [isMobile, setIsMobile] = useState(getIsMobile);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const nextIsMobile = getIsMobile();
+      setIsMobile((current) => (current === nextIsMobile ? current : nextIsMobile));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+};
+
+export default useIsMobileDevice;

--- a/frontend/src/pages/MobileHomePage.css
+++ b/frontend/src/pages/MobileHomePage.css
@@ -1,0 +1,220 @@
+.mobile-home {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mobile-home__hero {
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.2), rgba(0, 163, 255, 0.15));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.35rem 1.15rem;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+.mobile-home__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.75rem;
+}
+
+.mobile-home__headline {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 1.4rem;
+  line-height: 1.3;
+}
+
+.mobile-home__lede {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.mobile-home__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  width: fit-content;
+  color: #e2e8f0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.mobile-home__pill-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #cbd5e1;
+}
+
+.mobile-home__pill-value {
+  font-weight: 700;
+}
+
+.mobile-home__section {
+  background: rgba(12, 19, 34, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1rem 1rem 1.1rem;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.25);
+}
+
+.mobile-home__section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
+}
+
+.mobile-home__section-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #f8fafc;
+}
+
+.mobile-home__section-header p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.mobile-home__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 0.75rem;
+}
+
+.mobile-home__card {
+  text-align: left;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.9rem 0.95rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  color: #e2e8f0;
+  width: 100%;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mobile-home__card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+}
+
+.mobile-home__card-icon {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  font-size: 1.15rem;
+}
+
+.mobile-home__card-title {
+  margin: 0 0 0.15rem;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.mobile-home__card-copy {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.mobile-home__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.mobile-home__list-item {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 14px;
+  padding: 0.85rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.7rem;
+  align-items: center;
+  color: #e2e8f0;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mobile-home__list-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 163, 255, 0.4);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+}
+
+.mobile-home__list-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  font-size: 1rem;
+}
+
+.mobile-home__list-title {
+  margin: 0 0 0.1rem;
+  font-weight: 700;
+}
+
+.mobile-home__list-description {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+}
+
+.mobile-home__chevron {
+  font-size: 1.25rem;
+  color: #94a3b8;
+}
+
+.accent-blue {
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.15), rgba(0, 163, 255, 0.2));
+}
+
+.accent-green {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(34, 197, 94, 0.18));
+}
+
+.accent-orange {
+  background: linear-gradient(135deg, rgba(234, 179, 8, 0.16), rgba(251, 146, 60, 0.18));
+}
+
+.accent-purple {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.14), rgba(168, 85, 247, 0.18));
+}
+
+@media (max-width: 480px) {
+  .mobile-home__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mobile-home__section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/MobileHomePage.jsx
+++ b/frontend/src/pages/MobileHomePage.jsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { FaBarcode, FaClipboardList, FaTools, FaTruckLoading, FaBoxes, FaQuestionCircle } from 'react-icons/fa';
+import './MobileHomePage.css';
+
+const MobileHomePage = () => {
+  const { user } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+
+  const quickActions = useMemo(
+    () => [
+      {
+        title: 'Scan & Go',
+        description: 'Open the scanner to check tools in or out instantly.',
+        icon: <FaBarcode />,
+        onClick: () => navigate('/scanner'),
+        accent: 'accent-blue'
+      },
+      {
+        title: 'Find a Tool',
+        description: 'Search inventory, check availability, and start a checkout.',
+        icon: <FaTools />,
+        onClick: () => navigate('/tools?tab=search'),
+        accent: 'accent-green'
+      },
+      {
+        title: 'Request Something',
+        description: 'Create or track material and tooling requests.',
+        icon: <FaClipboardList />,
+        onClick: () => navigate('/requests'),
+        accent: 'accent-orange'
+      },
+      {
+        title: 'Receive & Returns',
+        description: 'Jump to orders and returns in one tap.',
+        icon: <FaTruckLoading />,
+        onClick: () => navigate('/orders'),
+        accent: 'accent-purple'
+      }
+    ],
+    [navigate]
+  );
+
+  const secondaryShortcuts = useMemo(
+    () => [
+      {
+        title: 'Kits & Stowage',
+        description: 'Open the mobile-first kit interface.',
+        icon: <FaBoxes />,
+        onClick: () => navigate('/kits')
+      },
+      {
+        title: 'Need help?',
+        description: 'Review help docs or open a support request.',
+        icon: <FaQuestionCircle />,
+        onClick: () => navigate('/dashboard?showHelp=true')
+      }
+    ],
+    [navigate]
+  );
+
+  return (
+    <div className="mobile-home">
+      <section className="mobile-home__hero">
+        <div>
+          <p className="mobile-home__eyebrow">Mobile cockpit</p>
+          <h2 className="mobile-home__headline">Everything you need for the flight line.</h2>
+          <p className="mobile-home__lede">
+            Designed for one-handed use. Big tap targets, clear actions, and instant access to the jobs you run
+            most.
+          </p>
+        </div>
+        <div className="mobile-home__pill">
+          <span className="mobile-home__pill-label">On duty</span>
+          <span className="mobile-home__pill-value">{user?.full_name || user?.username || 'You'}</span>
+        </div>
+      </section>
+
+      <section className="mobile-home__section">
+        <div className="mobile-home__section-header">
+          <h3>Quick actions</h3>
+          <p>One-tap entry to the flows techs use most.</p>
+        </div>
+        <div className="mobile-home__grid">
+          {quickActions.map((action) => (
+            <button
+              key={action.title}
+              type="button"
+              className={`mobile-home__card ${action.accent}`}
+              onClick={action.onClick}
+            >
+              <div className="mobile-home__card-icon" aria-hidden>
+                {action.icon}
+              </div>
+              <div>
+                <p className="mobile-home__card-title">{action.title}</p>
+                <p className="mobile-home__card-copy">{action.description}</p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="mobile-home__section">
+        <div className="mobile-home__section-header">
+          <h3>More shortcuts</h3>
+          <p>Stay productive without hunting through menus.</p>
+        </div>
+        <div className="mobile-home__list">
+          {secondaryShortcuts.map((shortcut) => (
+            <button
+              key={shortcut.title}
+              type="button"
+              className="mobile-home__list-item"
+              onClick={shortcut.onClick}
+            >
+              <div className="mobile-home__list-icon" aria-hidden>
+                {shortcut.icon}
+              </div>
+              <div className="mobile-home__list-copy">
+                <p className="mobile-home__list-title">{shortcut.title}</p>
+                <p className="mobile-home__list-description">{shortcut.description}</p>
+              </div>
+              <span className="mobile-home__chevron" aria-hidden>
+                →
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default MobileHomePage;


### PR DESCRIPTION
## Summary
- detect mobile sessions and reroute authenticated users to a new mobile experience
- add a mobile shell with sticky header and bottom navigation tailored to touch layouts
- build a mobile home hub with quick action cards and shortcuts to common workflows

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9657232c832cb84c5ae287bbb868)